### PR TITLE
Includes Merge pull request #170 from alchemy-containers/kakronst-patch-2 and more...

### DIFF
--- a/container_index.md
+++ b/container_index.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2014, 2017
-lastupdated: "2017-08-014"
+lastupdated: "2017-08-14"
 
 ---
 
@@ -26,7 +26,7 @@ Click an option to get started:
 <img usemap="#home_map" border="0" class="image" id="image_ztx_crb_f1b" src="images/cs_public_dedicated_options.png" width="440" alt="With Bluemix Public, you can create Kubernetes clusters or migrate single and scalable container groups to clusters. With Bluemix Dedicated, click this icon to see your options." style="width:440px;" />
 <map name="home_map" id="home_map">
 <area href="#clusters" alt="Getting started with Kubernetes clusters in Bluemix" title="Getting started with Kubernetes clusters in Bluemix" shape="rect" coords="-7, -8, 108, 211" />
-<area href="cs_classic.html#cs_classic" alt="Running single and scalable containers in IBM Bluemix Container Service (Kraken)" title="Running single and scalable containers in IBM Bluemix Container Service (Kraken)" shape="rect" coords="155, -1, 289, 210" />
+<area href="cs_classic.html#cs_classic" alt="Running single and scalable containers in IBM Bluemix Container Service" title="Running single and scalable containers in IBM Bluemix Container Service" shape="rect" coords="155, -1, 289, 210" />
 <area href="cs_ov.html#dedicated_environment" alt="Bluemix Dedicated cloud environment" title="Bluemix Dedicated cloud environment" shape="rect" coords="326, -10, 448, 218" />
 </map>
 

--- a/cs_apps.md
+++ b/cs_apps.md
@@ -1753,7 +1753,7 @@ To deploy your app:
 
 <!--Horizontal auto-scaling is not working at the moment due to a port issue with heapster. The dev team is working on a fix. We pulled out this content from the public docs. It is only visible in staging right now.-->
 
-Deploy cloud applications that respond to changes in demand for your applications and that use resources only when needed. Autoscaling automatically increases or decreases instances in your apps based on CPU.
+Deploy cloud applications that respond to changes in demand for your applications and that use resources only when needed. Autoscaling automatically increases or decreases the number of instances of your apps based on CPU.
 {:shortdesc}
 
 Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to your cluster.

--- a/cs_planning.md
+++ b/cs_planning.md
@@ -283,7 +283,7 @@ For more information about how to create a service of type cluster IP, see [Kube
 When you create a cluster, every cluster must be connected to a public VLAN. The public VLAN determines the public IP address that is assigned to a worker node during cluster creation.
 {:shortdesc}
 
-A public VLAN is protected by a {{site.data.keyword.BluSoftlayer_notm}} firewall that does not allow inbound or outbound connectivity to the internet by default. Although the Kubernetes master and the worker nodes communicate over the public VLAN by using their assigned public IP addresses, they cannot be reached from the internet.
+The public network interface for the worker nodes in both lite and standard clusters is protected by Calico network policies. These policies block most inbound traffic by default, including SSH. However, inbound traffic that is necessary for Kubernetes to function is allowed, as are connections to NodePort, Loadbalancer, and Ingress services. For more information about these policies, inlcuding how to modify them, see [Network policies](cs_security.html#cs_security_network_policies).
 
 |Cluster type|Manager of the public VLAN for the cluster|
 |------------|------------------------------------------|

--- a/cs_security.md
+++ b/cs_security.md
@@ -54,11 +54,11 @@ Review the built-in Kubernetes master security features to protect the Kubernete
 <dl>
   <dt>Fully managed and dedicated Kubernetes master</dt>
     <dd>Every Kubernetes cluster in {{site.data.keyword.containershort_notm}} is controlled by a dedicated Kubernetes master that is managed by IBM in an IBM-owned {{site.data.keyword.BluSoftlayer_full}} account. The Kubernetes master is set up with the following dedicated components that are not shared with other IBM customers.
-    <ul><ul><li>etcd data store: Stores all Kubernetes resources of a cluster, such as Services, Deployments, and Pods. Kubernetes ConfigMaps and Secrets are app data that are stored as key value pairs so that they can be used by an app that runs in a pod. Data in etcd is stored on an encrypted disk that is managed by IBM and is encrypted via TLS when sent to a pod to assure data protection and integrity.
-    <li>kube-apiserver: Serves as the main entry point for all requests from the worker node to the Kubernetes master. The kube-apiserver validates and processes requests and can read from and write to the etcd data store.
-    <li><kube-scheduler: Decides where to deploy pods, taking into account capacity and performance needs, hardware and software policy constraints, anti-affinity specifications, and workload requirements. If no worker node can be found that matches the requirements, the pod is not deployed in the cluster.
-    <li>kube-controller-manager: Responsible for monitoring replica sets, and creating corresponding pods to achieve the desired state.
-    <li>OpenVPN: {{site.data.keyword.containershort_notm}} specific component to provide secured network connectivity for all Kubernetes master to worker node communication.</ul></ul></dd>
+    <ul><li>etcd data store: Stores all Kubernetes resources of a cluster, such as Services, Deployments, and Pods. Kubernetes ConfigMaps and Secrets are app data that are stored as key value pairs so that they can be used by an app that runs in a pod. Data in etcd is stored on an encrypted disk that is managed by IBM and is encrypted via TLS when sent to a pod to assure data protection and integrity.</li>
+    <li>kube-apiserver: Serves as the main entry point for all requests from the worker node to the Kubernetes master. The kube-apiserver validates and processes requests and can read from and write to the etcd data store.</li>
+    <li>kube-scheduler: Decides where to deploy pods, taking into account capacity and performance needs, hardware and software policy constraints, anti-affinity specifications, and workload requirements. If no worker node can be found that matches the requirements, the pod is not deployed in the cluster.</li>
+    <li>kube-controller-manager: Responsible for monitoring replica sets, and creating corresponding pods to achieve the desired state.</li>
+    <li>OpenVPN: {{site.data.keyword.containershort_notm}} specific component to provide secured network connectivity for all Kubernetes master to worker node communication.</li></ul></dd>
   <dt>TLS secured network connectivity for all worker node to Kubernetes master communication</dt>
     <dd>To secure the network communication to the Kubernetes master, {{site.data.keyword.containershort_notm}} generates TLS certificates that encrypts the communication to and from the kube-apiserver and etcd data store components for every cluster. These certificates are never shared across clusters or across Kubernetes master components.</dd>
   <dt>OpenVPN secured network connectivity for all Kubernetes master to worker node communication</dt>
@@ -95,7 +95,7 @@ Review the built-in worker node security features to protect the worker node env
 ### Opening required ports and IP addresses in your firewall
 {: #opening_ports}
 
-When you set up a firewall for your worker nodes or customize the firewall settings in your {{site.data.keyword.BluSoftlayer_notm}} account, you must open certain ports and IP addresses so that the worker node and the Kubernetes master can communicate.
+When you set up a firewall for your worker nodes or customize the firewall settings in your {{site.data.keyword.BluSoftlayer_notm}} account, you must open certain ports and IP addresses so that the worker node and the Kubernetes master can communicate. To access the load balancer or Ingress controller from outside of the cluster, you must also open ports in your firewall.
 
 1.  Note the public IP address for all your worker nodes in the cluster.
 
@@ -111,7 +111,51 @@ When you set up a firewall for your worker nodes or customize the firewall setti
   ```
   {: codeblock}
 
-    <ul><li>For OUTBOUND connectivity from your worker nodes, allow outgoing network traffic from the source worker node to the destination TCP/UDP port range 20000-32767 for `<each_worker_node_publicIP>`, and the following IP addresses and network groups:</br>
+    <ul>
+    <li>For INBOUND connectivity to your worker nodes, allow incoming network traffic from the following source network groups and IP addresses to the destination TCP/UDP port 10250 and `<public_IP_of _each_worker_node>`:</br>
+    
+  <table summary="The first row in the table spans both columns. The rest of the rows should be read left to right, with the server location in column one and IP addresses to match in column two.">
+      <thead>
+      <th colspan=2><img src="images/idea.png"/> Inbound IP addresses</th>
+      </thead>
+    <tbody>
+      <tr>
+        <td>ams03</td>
+        <td><code>169.50.144.128/28</code></br><code>169.50.169.104/29</code></br><code>169.50.185.32/27</code></td>
+      </tr>
+      <tr>
+        <td>dal10</td>
+        <td><code>169.46.7.232/29</code></br><code>169.48.138.64/26</code></br><code>169.48.180.128/25</code></td>
+       </tr>
+       <tr>
+        <td>dal12</td>
+        <td><code>169.47.70.8/29</code></br><code>169.47.79.192/26</code></br><code>169.47.126.192/27</code></td>
+       </tr>
+       <tr>
+        <td>fra02</td>
+        <td><code>169.50.48.160/28</code></br><code>169.50.56.168/29</code></br><code>169.50.58.160/27</code></td>
+       </tr>
+      </tbody>
+      <tr>
+       <td>lon02</td>
+       <td><code>159.122.242.78</code></td>
+      </tr>
+      <tr>
+       <td>lon04</td>
+       <td><code>158.175.68.192/26</code></td>
+      </tr>
+      <tr>
+       <td>syd01</td>
+       <td><code>168.1.209.192/26</code></td>
+      </tr>
+      <tr>
+       <td>syd04</td>
+       <td><code>130.198.67.0/26</code></td>
+      </tr>
+    </table>
+
+    </li>
+    <li>For OUTBOUND connectivity from your worker nodes, allow outgoing network traffic from the source worker node to the destination TCP/UDP port range 20000-32767 for `<each_worker_node_publicIP>`, and the following IP addresses and network groups:</br>
     
   <table summary="The first row in the table spans both columns. The rest of the rows should be read left to right, with the server location in column one and IP addresses to match in column two.">
       <thead>
@@ -152,7 +196,13 @@ When you set up a firewall for your worker nodes or customize the firewall setti
        <td><code>130.198.64.19</code></td>
       </tr>
     </table>
-</ul>
+
+    </li>
+    </ul>
+
+3. Optional: To access the load balancer from outside of the cluster or VLAN, open the port for incoming network traffic on the specific IP address of that load balancer.
+ 
+4. Optional: To access the Ingress controller from outside of the cluster or VLAN, open either port 80 or 443 for incoming network traffic on the specific IP address of that Ingress controller, depending on which port you have configured.
 
 
 ## Network policies

--- a/cs_troubleshoot.md
+++ b/cs_troubleshoot.md
@@ -159,6 +159,25 @@ Review the options that you have to debug your clusters and find the root causes
     </tbody>
   </table>
 
+## Identifying local client and server versions of kubectl
+
+To check which version of the Kubernetes CLI that you are running locally or that your cluster is running, run the following command and check the version.
+
+```
+kubectl version  --short
+```
+{: pre}
+
+Example output:
+
+```
+Client Version: v1.5.6
+Server Version: v1.5.6
+```
+{: screen}
+
+
+
 ## Unable to connect to your IBM {{site.data.keyword.BluSoftlayer_notm}} account while creating a cluster
 {: #cs_credentials}
 
@@ -318,7 +337,7 @@ The deleted node is no longer listed in Calico.
 {: #cs_firewall}
 
 {: tsSymptoms}
-When kubectl proxy fails or you try to access a service in your cluster and your connection fails with one of the following error messages:
+When the worker nodes are not able to connect, you might see a variety of different symptoms. You might see one of the following messages when kubectl proxy fails or you try to access a service in your cluster and the connection fails.
 
   ```
   Connection refused
@@ -335,24 +354,24 @@ When kubectl proxy fails or you try to access a service in your cluster and your
   ```
   {: screen}
 
-Or when you use kubectl exec, attach, or logs and you receive this error:
+If you run kubectl exec, attach, or logs, you might see the following message.
 
   ```
   Error from server: error dialing backend: dial tcp XXX.XXX.XXX:10250: getsockopt: connection timed out
   ```
   {: screen}
 
-Or when kubectl proxy succeeds, but the dashboard is not available and you receive this error:
+If kubectl proxy succeeds, but the dashboard is not available, you might see the following message.
 
   ```
   timeout on 172.xxx.xxx.xxx
   ```
   {: screen}
 
-Or when your worker nodes are stuck in a reloading loop.
+
 
 {: tsCauses}
-You might have an additional firewall set up or customized your existing firewall settings in your {{site.data.keyword.BluSoftlayer_notm}} account. {{site.data.keyword.containershort_notm}} requires certain IP addresses and ports to be opened to allow communication from the worker node to the Kubernetes master and vice versa.
+You might have an additional firewall set up or customized your existing firewall settings in your {{site.data.keyword.BluSoftlayer_notm}} account. {{site.data.keyword.containershort_notm}} requires certain IP addresses and ports to be opened to allow communication from the worker node to the Kubernetes master and vice versa. Another reason might be that the worker nodes are stuck in a reloading loop.
 
 {: tsResolve}
 This task requires an [Administrator access policy](cs_cluster.html#access_ov). Verify your current [access policy](cs_cluster.html#view_access).

--- a/cs_tutorials.md
+++ b/cs_tutorials.md
@@ -28,7 +28,7 @@ Try out these tutorials and other resources to get started with the service.
 Deploy and manage your own Kubernetes cluster in the cloud that lets you automate the deployment, operation, scaling, and monitoring of containerized apps over a cluster of independent compute hosts called worker nodes.
 {:shortdesc}
 
-This tutorial series demonstrates how a fictional public relations firm can use Kubernetes to deploy a containerized app in {{site.data.keyword.Bluemix_short}} that leverages {{site.data.keyword.Watson}} Tone Analyzer. The PR firm uses {{site.data.keyword.Watson}} Tone Analyzer to analyze their press releases and receive feedback on the tone in their messages. In this first tutorial, the PR firm's networking administrator sets up a custom Kubernetes cluster that is the compute infrastructure for the firm's {{site.data.keyword.Watson}} Tone Analyzer app. This cluster is used to deploy and test a Hello World version of the PR firm's app.
+This tutorial series demonstrates how a fictional public relations firm can use Kubernetes to deploy a containerized app in {{site.data.keyword.Bluemix_short}} that leverages {{site.data.keyword.watson}} Tone Analyzer. The PR firm uses {{site.data.keyword.watson}} Tone Analyzer to analyze their press releases and receive feedback on the tone in their messages. In this first tutorial, the PR firm's networking administrator sets up a custom Kubernetes cluster that is the compute infrastructure for the firm's {{site.data.keyword.watson}} Tone Analyzer app. This cluster is used to deploy and test a Hello World version of the PR firm's app.
 
 ### Objectives
 


### PR DESCRIPTION
This PR includes the following changes:
Shortened image map title
updated cluster update
Revised short description
Removed email
Updated date
Revised  contact info
Fixed typo
Revised public networking
Revised worker nodes fail to connect
fixing date
added steps
updated cluster update steps
clarified priority
test width
Revised workers failed to connect
fixing formatting
update taint steps
kubectl version
Removed test
fixed watson conref
added linebreaks
beefed up worker update step
Merge pull request #142 from alchemy-containers/kakronst-patch-1
Added IDs
Added inbound connectivity
Merge pull request #170 from alchemy-containers/kakronst-patch-2