### PR TITLE
Includes adjust clarity of instruction and more...

### DIFF
--- a/cs_apps.md
+++ b/cs_apps.md
@@ -1178,6 +1178,7 @@ You can specify metadata for your Ingress resource to add capabilities to your I
 |[Client response data buffering](#response_buffer)|Disable the buffering of a client response on the Ingress controller while sending the response to the client.|
 |[Custom connect-timeouts and read-timeouts](#timeout)|Adjust the time the Ingress controller waits to connect to and read from the back-end app before the back-end app is considered to be not available.|
 |[Custom maximum client request body size](#client_max_body_size)|Adjust the size of the client request body that is allowed to be sent to the Ingress controller.|
+|[Custom HTTP and HTTPs ports](#custom_http_https_ports)|Change the default ports for HTTP and HTTPs network traffic.|
 
 
 ##### **Route incoming network traffic to a different path by using rewrites**
@@ -1613,6 +1614,99 @@ spec:
 
   </dd></dl>
   
+
+##### **Changing the default ports for HTTP and HTTPs network traffic**
+{: #custom_http_https_ports}
+
+Use this annotation to change the default ports for HTTP (port 80) and HTTPs (port 443) network traffic.
+{:shortdesc}
+
+<dl>
+<dt>Description</dt>
+<dd>By default, the Ingress controller is configured to listen for incoming HTTP network traffic on port 80 and for incoming HTTPS network traffic on port 443. You can change the default ports to add security to your Ingress controller domain, or to enable an HTTPS port only. 
+</dd>
+
+
+<dt>Sample Ingress resource YAML</dt>
+<dd>
+
+<pre class="codeblock">
+<code>apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: myingress
+  annotations:
+    ingress.bluemix.net/custom-port: "protocol=&lt;protocol1&gt; port=&lt;port1&gt;;protocol=&lt;protocol2&gt;port=&lt;port2&gt;"
+spec:
+  tls:
+  - hosts:
+    - mydomain
+    secretName: mytlssecret
+  rules:
+  - host: mydomain
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: myservice
+          servicePort: 8080</code></pre>
+
+<table>
+  <thead>
+  <th colspan=2><img src="images/idea.png"/> Understanding the YAML file components</th>
+  </thead>
+  <tbody>
+  <tr>
+  <td><code>annotations</code></td>
+  <td>Replace the following values:<ul><li><code><em>&lt;protocol&gt;</em></code>: Enter <strong>http</strong> or <strong>https</strong> to change the default port for incoming HTTP or HTTPS network traffic.</li>
+  <li><code><em>&lt;port&gt;</em></code>: Enter the port number that you want to use for incoming HTTP or HTTPS network traffic.</li></ul>
+  <p><strong>Note:</strong> When a custom port is specified for either HTTP or HTTPS, the default ports are no longer valid for both HTTP and HTTPS. For example, to change the default port for HTTPS to 8443, but use the default port for HTTP, you must set custom ports for both: <code>custom-port: "protocol=http port=80; protocol=https port=8443"</code>.</p>
+  </td>
+  </tr>
+  </tbody></table>
+
+  </dd>
+  <dt>Usage</dt>
+  <dd><ol><li>Review open ports for your Ingress controller.
+<pre class="pre">
+<code>kubectl get service -n kube-system</code></pre>
+Your CLI output looks similar to the following: 
+<pre class="screen">
+<code>NAME                     CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
+public-ingress-ctl-svc   10.10.10.149   169.60.16.246   80:30776/TCP,443:30412/TCP   8d</code></pre></li>
+<li>Open the Ingress controller config map. 
+<pre class="pre">
+<code>kubectl edit configmap ibm-cloud-provider-ingress-cm -n kube-system</code></pre></li>
+<li>Add the non-default HTTP and HTTPS ports to the config map. Replace &lt;port&gt; with the HTTP or HTTPS port that you want to open. 
+<pre class="codeblock">
+<code>apiVersion: v1
+kind: ConfigMap
+data:
+  public-ports: &lt;port1&gt;;&lt;port2&gt;
+metadata:
+  creationTimestamp: 2017-08-22T19:06:51Z
+  name: ibm-cloud-provider-ingress-cm
+  namespace: kube-system
+  resourceVersion: "1320"
+  selfLink: /api/v1/namespaces/kube-system/configmaps/ibm-cloud-provider-ingress-cm
+  uid: &lt;uid&gt;</code></pre></li>
+  <li>Verify that your Ingress controller is re-configured with the non-default ports.
+<pre class="pre">
+<code>kubectl get service -n kube-system</code></pre>
+Your CLI output looks similar to the following: 
+<pre class="screen">
+<code>NAME                     CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
+public-ingress-ctl-svc   10.10.10.149   169.60.16.246   &lt;port1&gt;:30776/TCP,&lt;port2&gt;:30412/TCP   8d</code></pre></li>
+<li>Configure your Ingress to use the non-default ports when routing incoming network traffic to your services. Use the sample YAML file in this reference. </li>
+<li>Update your Ingress controller configuration.
+<pre class="pre">
+<code>kubectl apply -f &lt;yaml_file&gt;</code></pre>
+</li>
+<li>Open your preferred web browser to access your app. Example: <code>https://&lt;ibmdomain&gt;:&lt;port&gt;/&lt;service_path&gt;/</code></li></ol></dd></dl>
+
+
+
+
 
 
 ## Managing IP addresses and subnets

--- a/cs_cluster.md
+++ b/cs_cluster.md
@@ -634,7 +634,7 @@ To create your own imagePullSecret:
     {: pre}
 
 3.  Note down the token ID that you want to use.
-4.  Retrieve the value for your token. Replace <token_id> with the ID of the token that you retrieved in the previous step.
+4.  Retrieve the value for your token. Replace <em>&lt;token_id&gt;</em> with the ID of the token that you retrieved in the previous step.
 
     ```
     bx cr token-get <token_id>
@@ -920,10 +920,12 @@ Add an existing {{site.data.keyword.Bluemix_notm}} service instance to your clus
 Before you begin:
 
 -   [Target your CLI](cs_cli_install.html#cs_cli_configure) to your cluster.
--   [Request an instance of the {{site.data.keyword.Bluemix_notm}} service](/docs/services/reqnsi.html#req_instance) in your space to add to your cluster.
+-   [Request an instance of the {{site.data.keyword.Bluemix_notm}} service](/docs/services/reqnsi.html#req_instance) in your space.
 -   For {{site.data.keyword.Bluemix_notm}} Dedicated users, see [Adding {{site.data.keyword.Bluemix_notm}} services to clusters in {{site.data.keyword.Bluemix_notm}} Dedicated (Closed Beta)](#binding_dedicated) instead.
 
-**Note:** You can only add {{site.data.keyword.Bluemix_notm}} services that support service keys (scroll to section [Enabling external apps to use {{site.data.keyword.Bluemix_notm}} services](/docs/services/reqnsi.html#req_instance)).
+**Note:** 
+- You can only add {{site.data.keyword.Bluemix_notm}} services that support service keys. If the service does not support service keys, see [Enabling external apps to use {{site.data.keyword.Bluemix_notm}} services](/docs/services/reqnsi.html#req_instance).
+- The cluster and the worker nodes must be deployed fully before you can add a service.
 
 To add a service:
 2.  List all existing services in your {{site.data.keyword.Bluemix_notm}} space.
@@ -989,6 +991,8 @@ To use the service in a pod that is deployed in the cluster, cluster users can a
 {: #binding_dedicated}
 
 Before you begin, [request an instance of the {{site.data.keyword.Bluemix_notm}} service](/docs/services/reqnsi.html#req_instance) in your space to add to your cluster.
+
+**Note**: The cluster and the worker nodes must be deployed fully before you can add a service.
 
 1.  Log in to the {{site.data.keyword.Bluemix_notm}} Dedicated environment where the service instance was created.
 

--- a/cs_ov.md
+++ b/cs_ov.md
@@ -148,13 +148,32 @@ To set up your Dedicated environment to use clusters:
     8.  Click **Invite users**.
 2.  [Create IBMIDs for the end users of your {{site.data.keyword.Bluemix_notm}} account. ![External link icon](../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/account/us-en/signup/register.html)
 3.  [Add the users from the previous step to your {{site.data.keyword.Bluemix_notm}} account.](cs_cluster.html#add_users)
-5.  Access your {{site.data.keyword.Bluemix_notm}} Dedicated account through the Public console and start creating clusters.
-
+4.  Access your {{site.data.keyword.Bluemix_notm}} Dedicated account through the Public console and start creating clusters.
     1.  Log in to {{site.data.keyword.Bluemix_notm}} Public console ([https://console.bluemix.net ![External link icon](../icons/launch-glyph.svg "External link icon")](https://console.bluemix.net)) with your IBMID.
     2.  From the account menu, select your {{site.data.keyword.Bluemix_notm}} Dedicated account. The console is updated with the services and information for your {{site.data.keyword.Bluemix_notm}} Dedicated instance.
     3.  From the catalog for your {{site.data.keyword.Bluemix_notm}} Dedicated instance, select **Containers** and click **Kubernetes cluster**.
+    For more information about creating a cluster, see [Creating Kubernetes clusters from the GUI in {{site.data.keyword.Bluemix_notm}} Dedicated (Closed Beta)](cs_cluster.html#creating_ui_dedicated).
+5. If your local system or your corporate network places controls on public internet endpoints via proxies or firewalls, allow outbound traffic through these controls to the following {{site.data.keyword.containershort_notm}} public endpoints.
 
-Next, for more information about creating a cluster, see [Creating Kubernetes clusters from the GUI in {{site.data.keyword.Bluemix_notm}} Dedicated (Closed Beta)](cs_cluster.html#creating_ui_dedicated).
+  <ul>
+  <li><code>&#60;region&#62;.containers.bluemix.net:443</code></li>
+  <li><code>api.&#60;region&#62;.bluemix.net:443</code></li>
+  <li><code>accountmanagement.&#60;region&#62;.bluemix.net:443</code></li>
+  <li>For each cluster, also allow <code>&#60;region&#62;.containers.bluemix.net:&#60;cluster-master-port&#62;</code>. To find the &#60;cluster-master-port&#62;:
+  <ol>
+  <li><a href="cs_cli_install.html#cs_cli_install" target="_blank">Install the CLI.</a></li>
+  <li><a href="cs_cli_install.html#cs_cli_configure" target="_blank">In the CLI, set the context for the cluster that you created.</a></li>
+  <li>Open the configuriation file that was set for the KUBECONFIG variable. Example: <code>/Users/&#60;user_name&#62;/.bluemix/plugins/container-service/clusters/&#60;cluster_name&#62;/kube-config-prod-dal10-&#60;cluster_name&#62;.yml</code></li>
+  <li>In the server field, identify the port that was assigned to access your cluster. In the following example, the &#60;cluster-master-port&#62; is 21264. Example: <pre class="screen"><code>server: https://192.168.10.38:21264</code></pre>
+  </ol></li>
+  </ul>
+  
+  **Tip**: For the <em>&#60;region&#62;</em> variables, you can enter one of the following regions.
+  -   US South: `ng`
+  -   Sydney: `au-syd`
+  -   Germany: `eu-de`
+  -   United Kingdom: `eu-gb`
+
 
 
 ## How Kubernetes clusters work 

--- a/cs_planning.md
+++ b/cs_planning.md
@@ -12,7 +12,7 @@ lastupdated: "2017-08-14"
 {:pre: .pre}
 {:table: .aria-labeledby="caption"}
 {:codeblock: .codeblock}
-{:tip: .tip} 
+{:tip: .tip}
 {:download: .download}
 
 
@@ -404,10 +404,10 @@ A container is, by design, short-lived. However, you can choose between several 
 {: caption="Table 5. Persistent data storage options for deployments in Kubernetes clusters" caption-side="top"}
 
 
-## Health monitoring
+## Monitoring and logging tools
 {: #cs_planning_health}
 
-You can use the standard Kubernetes and Docker features to monitor the health of your cluster and the apps that are deployed to it.
+You can use the standard Kubernetes and Docker features to monitor the health of your clusters and apps. You can also find logs for troubleshooting issues with your clusters and apps.
 {:shortdesc}
 <dl>
 <dt>Cluster details page in {{site.data.keyword.Bluemix_notm}}</dt>
@@ -416,8 +416,10 @@ You can use the standard Kubernetes and Docker features to monitor the health of
 <dd>The Kubernetes dashboard is an administrative web interface that you can use to review the health of your worker nodes, find Kubernetes resources, deploy containerized apps, and to troubleshoot apps based on logging and monitoring information. For more information about how to access your Kubernetes dashboard, see [Launching the Kubernetes dashboard for {{site.data.keyword.containershort_notm}}](cs_apps.html#cs_cli_dashboard).</dd>
 <dt>Docker logs</dt>
 <dd>You can leverage the built-in Docker logging capabilities to review activities on the standard STDOUT and STDERR output streams. For more information, see [Viewing container logs for a container that runs in a Kubernetes cluster](/docs/services/CloudLogAnalysis/containers/logging_containers_other_logs.html#logging_containers_collect_data).</dd>
-<dt>Logging and monitoring</dt>
-<dd>{{site.data.keyword.containershort_notm}} supports additional monitoring and logging capabilities for standard clusters. Logs and metrics are located in the {{site.data.keyword.Bluemix_notm}} space that was logged in to when the Kubernetes cluster was created.<ul><li>Container metrics are collected automatically for all containers that are deployed in a cluster. These metrics are sent and are made available through Grafana. For more information on metrics, see [Monitoring for the {{site.data.keyword.containershort_notm}}](/docs/services/cloud-monitoring/containers/analyzing_metrics_bmx_ui.html#analyzing_metrics_bmx_ui).<p>To access the Grafana dashboard, go to one of the following URLs and select the {{site.data.keyword.Bluemix_notm}} organization and space where you created the cluster.<ul><li>US-South: https://metrics.ng.bluemix.net</li><li>UK-South: https://metrics.eu-gb.bluemix.net</li><li>EU-Central: https://metrics.eu-de.bluemix.net</li></ul></p></li><li>Container logs are monitored and forwarded outside of the container. You can access logs for a container by using the Kibana dashboard. For more information on logging, see [Logging for the {{site.data.keyword.containershort_notm}}](/docs/services/CloudLogAnalysis/index.html#getting-started-with-cla).<p>To access the Kibana dashboard, go to one of the following URLs and select the {{site.data.keyword.Bluemix_notm}} organization and space where you created the cluster.<ul><li>US-South: https://logging.ng.bluemix.net</li><li>UK-South: https://logging.eu-gb.bluemix.net</li><li>EU-Central: https://logging.eu-de.bluemix.net</li></ul></p></li></ul></dd>
+<dt>{{site.data.keyword.monitoringlong_notm}}</dt>
+<dd>For standard clusters, metrics are located in the {{site.data.keyword.Bluemix_notm}} space that was logged in to when the Kubernetes cluster was created. Container metrics are collected automatically for all containers that are deployed in a cluster. These metrics are sent and are made available through Grafana. For more information on metrics, see [Monitoring for the {{site.data.keyword.containershort_notm}}](/docs/services/cloud-monitoring/containers/analyzing_metrics_bmx_ui.html#analyzing_metrics_bmx_ui).<p>To access the Grafana dashboard, go to one of the following URLs and select the {{site.data.keyword.Bluemix_notm}} organization and space where you created the cluster.<ul><li>US-South: https://metrics.ng.bluemix.net</li><li>UK-South: https://metrics.eu-gb.bluemix.net</li><li>EU-Central: https://metrics.eu-de.bluemix.net</li></ul></p></dd>
+<dt>{{site.data.keyword.loganalysislong_notm}}</dt>
+<dd>For standard clusters, logs are located in the {{site.data.keyword.Bluemix_notm}} space that was logged in to when the Kubernetes cluster was created. Container logs are monitored and forwarded outside of the container. You can access logs for a container by using the Kibana dashboard. For more information on logging, see [Logging for the {{site.data.keyword.containershort_notm}}](/docs/services/CloudLogAnalysis/containers/logging_containers_ov.html#logging_containers_ov).<p>To access the Kibana dashboard, go to one of the following URLs and select the {{site.data.keyword.Bluemix_notm}} organization and space where you created the cluster.<ul><li>US-South: https://logging.ng.bluemix.net</li><li>UK-South: https://logging.eu-gb.bluemix.net</li><li>EU-Central: https://logging.eu-de.bluemix.net</li></ul></p></dd>
 </dl>
 
 ### Other health monitoring tools

--- a/cs_troubleshoot.md
+++ b/cs_troubleshoot.md
@@ -159,6 +159,10 @@ Review the options to debug your clusters and find the root causes for failures.
     </tbody>
   </table>
 
+
+
+
+  
 ## Identifying local client and server versions of kubectl
 
 To check which version of the Kubernetes CLI that you are running locally or that your cluster is running, run the following command and check the version.
@@ -273,6 +277,24 @@ If this cluster is an existing one, check your cluster capacity.
   {: pre}
 
 5.  If your pods still stay in a **pending** state after the worker node is fully deployed, review the [Kubernetes documentation ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/tasks/debug-application-cluster/debug-pod-replication-controller/#my-pod-stays-pending) to further troubleshoot the pending state of your pod.
+
+
+
+
+
+
+## Containers do not start
+{: #containers_do_not_start}
+
+{: tsSymptoms}
+The pods deploy successfully to clusters, but the containers do not start.
+
+{: tsCauses}
+Containers might not start when the registry quota is reached.
+
+{: tsResolve}
+[Free up storage in {{site.data.keyword.registryshort_notm}}.](../services/Registry/registry_quota.html#registry_quota_freeup)
+  
 
 
 ## Accessing a pod on a new worker node fails with a timeout


### PR DESCRIPTION
This PR includes the following changes:
SEO revisions from Jason
Merge pull request #190 from alchemy-containers/rlg_planning-log-link
revised versions to clarify flow
added nodespec steps
Added steps for finding port
Fixed code block
Merge branch 'master' of github.ibm.com:alchemy-containers/documentation
Added variable
Added regions
Added tip
Added italics for variables
Fixed product names
Merge pull request #180 from alchemy-containers/kakronst-debugging-apps
fixed link
Added note to service binding that cluster and nodes must be fully deployed
Removed tags from dedicated endpoints steps
Added containers do not start
Fixed product name
Added default port annotation
Added link for custom ports
applied feedback
Updates
Merge branch 'master' of github.ibm.com:alchemy-containers/documentation
adjust clarity of instruction