### PR TITLE
Fixed typo in kubectl mv command

### DIFF
--- a/cs_cli_install.md
+++ b/cs_cli_install.md
@@ -87,7 +87,7 @@ To install the CLIs:
         1.  Move the executable file to the `/usr/local/bin` directory.
 
             ```
-            mv /<path_to_file>/kubectl/usr/local/bin/kubectl
+            mv /<path_to_file>/kubectl /usr/local/bin/kubectl
             ```
             {: pre}
 


### PR DESCRIPTION
Code command was missing a space between the file to move and the destination.