### PR TITLE
Updating to reflect new global endpoints and identity routes

### DIFF
--- a/cs_cli_install.md
+++ b/cs_cli_install.md
@@ -678,7 +678,7 @@ Use the following steps if you want to refresh your IAM token.
 1.  Generate a new IAM access token. Replace _&lt;iam_refresh_token&gt;_ with the IAM refresh token that you received when you authenticated with {{site.data.keyword.Bluemix_notm}}.
 
     ```
-    POST https://iam.ng.bluemix.net/oidc/token
+    POST https://iam.bluemix.net/identity/token
     ```
     {: codeblock}
 


### PR DESCRIPTION
There are new global endpoints and identity routes that went live in October. We no longer use the regional endpoints with .ng for staging or production. In addition to that the routes have changed to reflect the following

New global (and local) endpoints
•https://<iam>/oidc/is deprecated,  but remains  valid with existing behavior
•https://<iam>/identity/ is the new endpoint  path for global  and local (UI-related) invocations
•Update  your invocation of endpoints  like .../oidc/token or .../oidc/keys to use .../identity/token or .../identity/keys

