### PR TITLE
Includes calico policy v2.6 links and more...

### DIFF
--- a/cs_annotations.md
+++ b/cs_annotations.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2014, 2018
-lastupdated: "2017-01-04"
+lastupdated: "2017-01-08"
 
 ---
 
@@ -24,37 +24,145 @@ To add capabilities to your application load balancer, you can specify annotatio
 
 For general information about Ingress services and how to get started using them, see [Configuring public access to an app by using Ingress](cs_apps.html#cs_apps_public_ingress).
 
+<table>
+<col width="25%">
+ <thead>
+ <th colspan=2>General annotations</th>
+ </thead>
+ <tbody>
+ <tr>
+ <td><a href="#proxy-external-service">External services</a></td>
+ <td>Add path definitions to external services, such as a service hosted in {{site.data.keyword.Bluemix_notm}}.</td>
+ </tr>
+ <tr>
+ <td><a href="#alb-id">Private application load balancer routing</a></td>
+ <td>Route incoming requests to your apps with a private application load balancer.</td>
+ </tr>
+ <tr>
+ <td><a href="#rewrite-path">Rewrite paths</a></td>
+ <td>Route incoming network traffic to a different path that your back-end app listens on.</td>
+ </tr>
+ <tr>
+ <td><a href="#sticky-cookie-services">Session-affinity with cookies</a></td>
+ <td>Always route incoming network traffic to the same upstream server by using a sticky cookie.</td>
+ </tr>
+ <tr>
+ <td><a href="#tcp-ports">TCP ports</a></td>
+ <td>Access an app via a non-standard TCP port.</td>
+ </tr>
+ </tbody></table>
 
-|Supported annotation|Description|
-|-----------|-------------------|
-|**General annotations**||
-|[External services](#proxy-external-service)|Add path definitions to external services, such as a service hosted in {{site.data.keyword.Bluemix_notm}}.|
-|[Private application load balancer routing](#alb-id)|Route incoming requests to your apps with a private application load balancer.|
-|[Rewrite paths](#rewrite-path)|Route incoming network traffic to a different path that your back-end app listens on.|
-|[Session-affinity with cookies](#sticky-cookie-services)|Always route incoming network traffic to the same upstream server by using a sticky cookie.|
-|[TCP ports](#tcp-ports)|Access an app via a non-standard TCP port.|
-|**Connection annotations**||
-|[Custom connect-timeouts and read-timeouts](#proxy-connect-timeout)|Adjust the time that the application load balancer waits to connect to and read from the back-end app before the back-end app is considered unavailable.|
-|[Keepalive requests](#keepalive-requests)|Configure the maximum number of requests that can be served through one keepalive connection.|
-|[Keepalive timeout](#keepalive-timeout)|Configure the time that a keepalive connection stays open on the server.|
-|[Upstream keepalive](#upstream-keepalive)|Configure the maximum number of idle keepalive connections for an upstream server.|
-|**Proxy buffer annotations**||
-|[Client response data buffering](#proxy-buffering)|Disable the buffering of a client response on the application load balancer while sending the response to the client.|
-|[Proxy buffers](#proxy-buffers)|Set the number and size of the buffers that read a response for a single connection from the proxied server.|
-|[Proxy buffer size](#proxy-buffer-size)|Set the size of the buffer that reads the first part of the response that is received from the proxied server.|
-|[Proxy busy buffers size](#proxy-busy-buffers-size)|Set the size of proxy buffers that can be busy.|
-|**Request and response annotations**||
-|[Additional client request or response header](#proxy-add-headers)|Add header information to a client request before forwarding the request to your back-end app or to a client response before sending the response to the client.|
-|[Client response header removal](#response-remove-headers)|Remove header information from a client response before forwarding the response to the client.|
-|[Custom maximum client request body size](#client-max-body-size)|Adjust the size of the client request body that is allowed to be sent to the application load balancer.|
-|**Service limit annotations**||
-|[Global rate limits](#global-rate-limit)|Limit the request processing rate and number of connections per a defined key for all services.|
-|[Service rate limits](#service-rate-limit)|Limit the request processing rate and the number of connections per a defined key for specific services.|
-|**TLS/SSL authentication annotations**||
-|[Custom HTTP and HTTPS ports](#custom-port)|Change the default ports for HTTP (port 80) and HTTPS (port 443) network traffic.|
-|[HTTP redirects to HTTPS](#redirect-to-https)|Redirect insecure HTTP requests on your domain to HTTPS.|
-|[Mutual authentication](#mutual-auth)|Configure mutual authentication for the application load balancer.|
-|[SSL services support](#ssl-services)|Allow SSL services support for load balancing.|
+
+ <table>
+ <col width="25%">
+  <thead>
+  <th colspan=2>Connection annotations</th>
+  </thead>
+  <tbody>
+  <tr>
+  <td><a href="#proxy-connect-timeout">Custom connect-timeouts and read-timeouts</a></td>
+  <td>Adjust the time that the application load balancer waits to connect to and read from the back-end app before the back-end app is considered unavailable.</td>
+  </tr>
+  <tr>
+  <td><a href="#keepalive-requests">Keepalive requests</a></td>
+  <td>Configure the maximum number of requests that can be served through one keepalive connection.</td>
+  </tr>
+  <tr>
+  <td><a href="#keepalive-timeout">Keepalive timeout</a></td>
+  <td>Configure the time that a keepalive connection stays open on the server.</td>
+  </tr>
+  <tr>
+  <td><a href="#upstream-keepalive">Upstream keepalive</a></td>
+  <td>Configure the maximum number of idle keepalive connections for an upstream server.</td>
+  </tr>
+  </tbody></table>
+
+
+<table>
+<col width="25%">
+ <thead>
+ <th colspan=2>Proxy buffer annotations</th>
+ </thead>
+ <tbody>
+ <tr>
+ <td><a href="#proxy-buffering">Client response data buffering</a></td>
+ <td>Disable the buffering of a client response on the application load balancer while sending the response to the client.</td>
+ </tr>
+ <tr>
+ <td><a href="#proxy-buffers">Proxy buffers</a></td>
+ <td>Set the number and size of the buffers that read a response for a single connection from the proxied server.</td>
+ </tr>
+ <tr>
+ <td><a href="#proxy-buffer-size">Proxy buffer size</a></td>
+ <td>Set the size of the buffer that reads the first part of the response that is received from the proxied server.</td>
+ </tr>
+ <tr>
+ <td><a href="#proxy-busy-buffers-size">Proxy busy buffers size</a></td>
+ <td>Set the size of proxy buffers that can be busy.</td>
+ </tr>
+ </tbody></table>
+
+
+<table>
+<col width="25%">
+<thead>
+<th colspan=2>Request and response annotations</th>
+</thead>
+<tbody>
+<tr>
+<td><a href="#proxy-add-headers">Additional client request or response header</a></td>
+<td>Add header information to a client request before forwarding the request to your back-end app or to a client response before sending the response to the client.</td>
+</tr>
+<tr>
+<td><a href="#response-remove-headers">Client response header removal</a></td>
+<td>Remove header information from a client response before forwarding the response to the client.</td>
+</tr>
+<tr>
+<td><a href="#client-max-body-size">Custom maximum client request body size</a></td>
+<td>Adjust the size of the client request body that is allowed to be sent to the application load balancer.</td>
+</tr>
+</tbody></table>
+
+<table>
+<col width="25%">
+<thead>
+<th colspan=2>Service limit annotations</th>
+</thead>
+<tbody>
+<tr>
+<td><a href="#global-rate-limit">Global rate limits</a></td>
+<td>Limit the request processing rate and number of connections per a defined key for all services.</td>
+</tr>
+<tr>
+<td><a href="#service-rate-limit">Service rate limits</a></td>
+<td>Limit the request processing rate and the number of connections per a defined key for specific services.</td>
+</tr>
+</tbody></table>
+
+<table>
+<col width="25%">
+<thead>
+<th colspan=2>HTTPS and TLS/SSL authentication annotations</th>
+</thead>
+<tbody>
+<tr>
+<td><a href="#custom-port">Custom HTTP and HTTPS ports</a></td>
+<td>Change the default ports for HTTP (port 80) and HTTPS (port 443) network traffic.</td>
+</tr>
+<tr>
+<td><a href="#redirect-to-https">HTTP redirects to HTTPS</a></td>
+<td>Redirect insecure HTTP requests on your domain to HTTPS.</td>
+</tr>
+<tr>
+<td><a href="#mutual-auth">Mutual authentication</a></td>
+<td>Configure mutual authentication for the application load balancer.</td>
+</tr>
+<tr>
+<td><a href="#ssl-services">SSL services support</a></td>
+<td>Allow SSL services support for load balancing.</td>
+</tr>
+</tbody></table>
+
 
 
 ## General annotations
@@ -80,17 +188,17 @@ kind: Ingress
 metadata:
   name: cafe-ingress
   annotations:
-    ingress.bluemix.net/proxy-external-service: "path=&lt;path&gt; external-svc=https:&lt;external_service&gt; host=&lt;mydomain&gt;"
+    ingress.bluemix.net/proxy-external-service: "path=&lt;mypath&gt; external-svc=https:&lt;external_service&gt; host=&lt;mydomain&gt;"
 spec:
   tls:
   - hosts:
-    - &lt;mydomain&gt;
+    - mydomain
     secretName: mysecret
   rules:
-  - host: &lt;mydomain&gt;
+  - host: mydomain
     http:
       paths:
-      - path: &lt;path&gt;
+      - path: /
         backend:
           serviceName: myservice
           servicePort: 80
@@ -102,11 +210,16 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following value:
- <ul>
- <li><code><em>&lt;external_service&gt;</em></code>: Enter the external service to be called. For example, https://&lt;myservice&gt;.&lt;region&gt;.mybluemix.net.</li>
- </ul>
+ <td><code>path</code></td>
+ <td>Replace <code>&lt;<em>mypath</em>&gt;</code> with the path that the external service listens on.</td>
+ </tr>
+ <tr>
+ <td><code>external-svc</code></td>
+ <td>Replace <code>&lt;<em>external_service</em>&gt;</code> with the external service to be called. For example, <code>https://&lt;myservice&gt;.&lt;region&gt;.mybluemix.net</code>.</td>
+ </tr>
+ <tr>
+ <td><code>host</code></td>
+ <td>Replace <code>&lt;<em>mydomain</em>&gt;</code> with the host domain for the external service.</td>
  </tr>
  </tbody></table>
 
@@ -158,8 +271,8 @@ rules:
 </thead>
 <tbody>
 <tr>
-<td><code>annotations</code></td>
-<td>Replace <em>&lt;private_ALB_ID&gt;</em> with the ID for your private application load balancer. Run <code>bx cs albs --cluster <my_cluster></code> to find the application load balancer ID.
+<td><code>&lt;private_ALB_ID&gt;</code></td>
+<td>The ID for your private application load balancer. Run <code>bx cs albs --cluster <my_cluster></code> to find the private application load balancer ID.
 </td>
 </tr>
 </tbody></table>
@@ -187,24 +300,21 @@ kind: Ingress
 metadata:
   name: myingress
   annotations:
-    ingress.bluemix.net/rewrite-path: "serviceName=&lt;service_name1&gt; rewrite=&lt;target_path1&gt;;serviceName=&lt;service_name2&gt; rewrite=&lt;target_path2&gt;"
+    ingress.bluemix.net/rewrite-path: "serviceName=&lt;myservice1&gt; rewrite=&lt;target_path1&gt;;serviceName=&lt;myservice2&gt; rewrite=&lt;target_path2&gt;"
 spec:
   tls:
   - hosts:
     - mydomain
-    secretName: &lt;mytlssecret&gt;
+    secretName: mysecret
   rules:
   - host: mydomain
     http:
       paths:
-      - path: /&lt;domain_path1&gt;
+      - path: /beans
         backend:
-          serviceName: &lt;service_name1&gt;
-          servicePort: &lt;service_port1&gt;
-      - path: /&lt;domain_path2&gt;
-        backend:
-          serviceName: &lt;service_name2&gt;
-          servicePort: &lt;service_port2&gt;</code></pre>
+          serviceName: myservice1
+          servicePort: 80
+</code></pre>
 
 <table>
 <thead>
@@ -212,21 +322,14 @@ spec:
 </thead>
 <tbody>
 <tr>
-<td><code>annotations</code></td>
-<td>Replace <em>&lt;service_name&gt;</em> with the name of the Kubernetes service that you created for your app, and <em>&lt;target-path&gt;</em> with the path that your app listens on. Incoming network traffic on the application load balancer domain is forwarded to the Kubernetes service by using this path. Most apps do not listen on a specific path, but use the root path and a specific port. In this case, define <code>/</code> as the <em>rewrite-path</em> for your app.</td>
-</tr>
-<tr>
-<td><code>path</code></td>
-<td>Replace <em>&lt;domain_path&gt;</em> with the path that you want to append to your application load balancer domain. Incoming network traffic on this path is forwarded to the rewrite path that you defined in your annotation. In the example above, set the domain path to <code>/beans</code> to include this path into the load balancing of your Ingress controller.</td>
-</tr>
-<tr>
 <td><code>serviceName</code></td>
-<td>Replace <em>&lt;service_name&gt;</em> with the name of the Kubernetes service that you created for your app. The service name that you use here must be the same name that you defined in your annotation.</td>
+<td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app.</td>
 </tr>
 <tr>
-<td><code>servicePort</code></td>
-<td>Replace <em>&lt;service_port&gt;</em> with the port that your service listens on.</td>
-</tr></tbody></table>
+<td><code>rewrite</code></td>
+<td>Replace <code>&lt;<em>target_path</em>&gt;</code> with the path that your app listens on. Incoming network traffic on the application load balancer domain is forwarded to the Kubernetes service by using this path. Most apps do not listen on a specific path, but use the root path and a specific port. In the example above, the rewrite path was defined as <code>/coffee</code>.</td>
+</tr>
+</tbody></table>
 
 </dd></dl>
 
@@ -257,7 +360,7 @@ kind: Ingress
 metadata:
   name: myingress
   annotations:
-    ingress.bluemix.net/sticky-cookie-services: "serviceName=&lt;service_name1&gt; name=&lt;cookie_name1&gt; expires=&lt;expiration_time1&gt; path=&lt;cookie_path1&gt; hash=&lt;hash_algorithm1&gt;;serviceName=&lt;service_name2&gt; name=&lt;cookie_name2&gt; expires=&lt;expiration_time2&gt; path=&lt;cookie_path2&gt; hash=&lt;hash_algorithm2&gt;"
+    ingress.bluemix.net/sticky-cookie-services: "serviceName=&lt;myservice1&gt; name=&lt;cookie_name1&gt; expires=&lt;expiration_time1&gt; path=&lt;cookie_path1&gt; hash=&lt;hash_algorithm1&gt;;serviceName=&lt;myservice2&gt; name=&lt;cookie_name2&gt; expires=&lt;expiration_time2&gt; path=&lt;cookie_path2&gt; hash=&lt;hash_algorithm2&gt;"
 spec:
   tls:
   - hosts:
@@ -269,11 +372,11 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: &lt;service_name1&gt;
+          serviceName: &lt;myservice1&gt;
           servicePort: 8080
       - path: /myapp
         backend:
-          serviceName: &lt;service_name2&gt;
+          serviceName: &lt;myservice2&gt;
           servicePort: 80</code></pre>
 
   <table>
@@ -283,14 +386,24 @@ spec:
   </thead>
   <tbody>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;service_name&gt;</em></code>: The name of the Kubernetes service that you created for your app.</li>
-  <li><code><em>&lt;cookie_name&gt;</em></code>: Choose a name of the sticky cookie that is created during a session.</li>
-  <li><code><em>&lt;expiration_time&gt;</em></code>: The time in seconds, minutes, or hours before the sticky cookie expires. This time is independent of the user activity. After the cookie is expired, the cookie is deleted by the client web browser and no longer sent to the application load balancer. For example, to set an expiration time of 1 second, 1 minute, or 1 hour, enter <strong>1s</strong>, <strong>1m</strong>, or <strong>1h</strong>.</li>
-  <li><code><em>&lt;cookie_path&gt;</em></code>: The path that is appended to the Ingress subdomain and that indicates for which domains and subdomains the cookie is sent to the application load balancer. For example, if your Ingress domain is <code>www.myingress.com</code> and you want to send the cookie in every client request, you must set <code>path=/</code>. If you want to send the cookie only for <code>www.myingress.com/myapp</code> and all its subdomains, then you must set <code>path=/myapp</code>.</li>
-  <li><code><em>&lt;hash_algorithm&gt;</em></code>: The hash algorithm that protects the information in the cookie. Only <code>sha1</code> is supported. SHA1 creates a hash sum based on the information in the cookie and appends this hash sum to the cookie. The server can decrypt the information in the cookie and verify data integrity.
-  </li></ul></td>
+  <td><code>serviceName</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app.</td>
+  </tr>
+  <tr>
+  <td><code>name</code></td>
+  <td>Replace <code>&lt;<em>cookie_name</em>&gt;</code> with the name of a sticky cookie that is created during a session.</td>
+  </tr>
+  <tr>
+  <td><code>expires</code></td>
+  <td>Replace <code>&lt;<em>expiration_time</em>&gt;</code> with the time in seconds (s), minutes (m), or hours (h) before the sticky cookie expires. This time is independent of the user activity. After the cookie is expired, the cookie is deleted by the client web browser and no longer sent to the application load balancer. For example, to set an expiration time of 1 second, 1 minute, or 1 hour, enter <code>1s</code>, <code>1m</code>, or <code>1h</code>.</td>
+  </tr>
+  <tr>
+  <td><code>path</code></td>
+  <td>Replace <code>&lt;<em>cookie_path</em>&gt;</code> with the path that is appended to the Ingress subdomain and that indicates for which domains and subdomains the cookie is sent to the application load balancer. For example, if your Ingress domain is <code>www.myingress.com</code> and you want to send the cookie in every client request, you must set <code>path=/</code>. If you want to send the cookie only for <code>www.myingress.com/myapp</code> and all its subdomains, then you must set <code>path=/myapp</code>.</td>
+  </tr>
+  <tr>
+  <td><code>hash</code></td>
+  <td>Replace <code>&lt;<em>hash_algorithm</em>&gt;</code> with the hash algorithm that protects the information in the cookie. Only <code>sha1</code> is supported. SHA1 creates a hash sum based on the information in the cookie and appends this hash sum to the cookie. The server can decrypt the information in the cookie and verify data integrity.</td>
   </tr>
   </tbody></table>
 
@@ -315,29 +428,29 @@ Use this annotation for an app that is running a TCP streams workload.
 </dd>
 
 
- <dt>Sample Ingress resource YAML</dt>
- <dd>
+<dt>Sample Ingress resource YAML</dt>
+<dd>
 
- <pre class="codeblock">
- <code>apiVersion: extensions/v1beta1
- kind: Ingress
- metadata:
-  name: myingress
-  annotations:
-    ingress.bluemix.net/tcp-ports: "serviceName=&lt;service_name&gt; ingressPort=&lt;ingress_port&gt; [servicePort=&lt;service_port&gt;]"
- spec:
+<pre class="codeblock">
+<code>apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+name: myingress
+annotations:
+  ingress.bluemix.net/tcp-ports: "serviceName=&lt;myservice&gt; ingressPort=&lt;ingress_port&gt; [servicePort=&lt;service_port&gt;]"
+spec:
   tls:
   - hosts:
     - mydomain
-    secretName: mytlssecret
+    secretName: mysecret
   rules:
   - host: mydomain
     http:
       paths:
       - path: /
         backend:
-          serviceName: myservice
-          servicePort: 8080</code></pre>
+          serviceName: &lt;myservice&gt;
+          servicePort: 80</code></pre>
 
  <table>
   <thead>
@@ -345,13 +458,16 @@ Use this annotation for an app that is running a TCP streams workload.
   </thead>
   <tbody>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;ingressPort&gt;</em></code>: The TCP port on which you want to access your app.</li>
-  <li><code><em>&lt;serviceName&gt;</em></code>: The name of the Kubernetes service to access over non-standard TCP port.</li>
-  <li><code><em>&lt;servicePort&gt;</em></code>: This parameter is optional. When provided, the port is substituted to this value before traffic is sent to the backend app. Otherwise, the port remains same as the Ingress port.</li>
-  </ul>
-  </td>
+  <td><code>serviceName</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service to access over non-standard TCP port.</td>
+  </tr>
+  <tr>
+  <td><code>ingressPort</code></td>
+  <td>Replace <code>&lt;<em>ingress_port</em>&gt;</code> with the TCP port on which you want to access your app.</td>
+  </tr>
+  <tr>
+  <td><code>servicePort</code></td>
+  <td>Replace <code>&lt;<em>service_port</em>&gt;</code> with this parameter is optional. When provided, the port is substituted to this value before traffic is sent to the backend app. Otherwise, the port remains same as the Ingress port.</td>
   </tr>
   </tbody></table>
   </dd>
@@ -413,11 +529,12 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following values:<ul><li><code><em>&lt;connect_timeout&gt;</em></code>: Enter the number of seconds to wait to connect to the back-end app, for example <strong>65s</strong>.
-
- </br></br>
- <strong>Note:</strong> A connect-timeout cannot exceed 75 seconds.</li><li><code><em>&lt;read_timeout&gt;</em></code>: Enter the number of seconds to wait before the back-end app is read, for example <strong>65s</strong>.</li></ul></td>
+ <td><code>&lt;connect_timeout&gt;</code></td>
+ <td>The number of seconds to wait to connect to the back-end app, for example <code>65s</code>. <strong>Note:</strong> A connect-timeout cannot exceed 75 seconds.</td>
+ </tr>
+ <tr>
+ <td><code>&lt;read_timeout&gt;</code></td>
+ <td>The number of seconds to wait before the back-end app is read, for example <code>65s</code>.</td>
  </tr>
  </tbody></table>
 
@@ -449,7 +566,7 @@ kind: Ingress
 metadata:
 name: myingress
 annotations:
-  ingress.bluemix.net/keepalive-requests: "serviceName=&lt;service_name&gt; requests=&lt;max_requests&gt;"
+  ingress.bluemix.net/keepalive-requests: "serviceName=&lt;myservice&gt; requests=&lt;max_requests&gt;"
 spec:
 tls:
 - hosts:
@@ -461,7 +578,7 @@ rules:
     paths:
     - path: /
       backend:
-        serviceName: myservice
+        serviceName: &lt;myservice&gt;
         servicePort: 8080</code></pre>
 
 <table>
@@ -470,12 +587,12 @@ rules:
 </thead>
 <tbody>
 <tr>
-<td><code>annotations</code></td>
-<td>Replace the following values:<ul>
-<li><code><em>&lt;serviceName&gt;</em></code>: Replace <em>&lt;service_name&gt;</em> with the name of the Kubernetes service that you created for your app. This parameter is optional. The configuration is applied to all of the services in the Ingress host unless a service is specified. If the parameter is provided, the keepalive requests are set for the given service. If the parameter is not provided, the keepalive requests are set at the server level of the <code>nginx.conf</code> for all the services that do not have the keepalive requests configured.</li>
-<li><code><em>&lt;requests&gt;</em></code>: Replace <em>&lt;max_requests&gt;</em> with the maximum number of requests that can be served through one keepalive connection.</li>
-</ul>
-</td>
+<td><code>serviceName</code></td>
+<td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app. This parameter is optional. The configuration is applied to all of the services in the Ingress host unless a service is specified. If the parameter is provided, the keepalive requests are set for the given service. If the parameter is not provided, the keepalive requests are set at the server level of the <code>nginx.conf</code> for all the services that do not have the keepalive requests configured.</td>
+</tr>
+<tr>
+<td><code>requests</code></td>
+<td>Replace <code>&lt;<em>max_requests</em>&gt;</code> with the maximum number of requests that can be served through one keepalive connection.</td>
 </tr>
 </tbody></table>
 
@@ -508,7 +625,7 @@ kind: Ingress
 metadata:
  name: myingress
  annotations:
-   ingress.bluemix.net/keepalive-timeout: "serviceName=&lt;service_name&gt; timeout=&lt;time&gt;s"
+   ingress.bluemix.net/keepalive-timeout: "serviceName=&lt;myservice&gt; timeout=&lt;time&gt;s"
 spec:
  tls:
  - hosts:
@@ -529,12 +646,12 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following values:<ul>
- <li><code><em>&lt;serviceName&gt;</em></code>: Replace <em>&lt;service_name&gt;</em> with the name of the Kubernetes service that you created for your app. This parameter is optional. If the parameter is provided, the keepalive timeout is set for the given service. If the parameter is not provided, the keepalive timeout is set at the server level of the <code>nginx.conf</code> for all the services that do not have the keepalive timeout configured.</li>
- <li><code><em>&lt;timeout&gt;</em></code>: Replace <em>&lt;time&gt;</em> with an amount of time in seconds. Example:<code><em>timeout=20s</em></code>. A zero value disables the keepalive client connections.</li>
- </ul>
- </td>
+ <td><code>serviceName</code></td>
+ <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app. This parameter is optional. If the parameter is provided, the keepalive timeout is set for the given service. If the parameter is not provided, the keepalive timeout is set at the server level of the <code>nginx.conf</code> for all the services that do not have the keepalive timeout configured.</td>
+ </tr>
+ <tr>
+ <td><code>timeout</code></td>
+ <td>Replace <code>&lt;<em>time</em>&gt;</code> with an amount of time in seconds. Example: <code>timeout=20s</code>. A zero value disables the keepalive client connections.</td>
  </tr>
  </tbody></table>
 
@@ -567,7 +684,7 @@ Change the maximum number of idle keepalive connections to the upstream server o
  metadata:
   name: myingress
   annotations:
-    ingress.bluemix.net/upstream-keepalive: "serviceName=&lt;service_name&gt; keepalive=&lt;max_connections&gt;"
+    ingress.bluemix.net/upstream-keepalive: "serviceName=&lt;myservice&gt; keepalive=&lt;max_connections&gt;"
  spec:
   tls:
   - hosts:
@@ -588,18 +705,19 @@ Change the maximum number of idle keepalive connections to the upstream server o
   </thead>
   <tbody>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;serviceName&gt;</em></code>: Replace <em>&lt;service_name&gt;</em> with the name of the Kubernetes service that you created for your app.</li>
-  <li><code><em>&lt;keepalive&gt;</em></code>: Replace <em>&lt;max_connections&gt;</em> with the maximum number of idle keepalive connections to the upstream server. The default is 64. A zero value disables upstream keepalive connections for the given service.</li>
-  </ul>
-  </td>
+  <td><code>serviceName</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app.</td>
+  </tr>
+  <tr>
+  <td><code>keepalive</code></td>
+  <td>Replace <code>&lt;<em>max_connections</em>&gt;</code> with the maximum number of idle keepalive connections to the upstream server. The default is <code>64</code>. A <code>0</code> value disables upstream keepalive connections for the given service.</td>
   </tr>
   </tbody></table>
   </dd>
   </dl>
 
-{[whitespace.md]}
+<br />
+
 
 
 ## Proxy buffer annotations
@@ -668,7 +786,7 @@ kind: Ingress
 metadata:
  name: proxy-ingress
  annotations:
-   ingress.bluemix.net/proxy-buffers: "serviceName=&lt;service_name&gt; number=&lt;number_of_buffers&gt; size=&lt;size&gt;"
+   ingress.bluemix.net/proxy-buffers: "serviceName=&lt;myservice&gt; number=&lt;number_of_buffers&gt; size=&lt;size&gt;"
 spec:
  tls:
  - hosts:
@@ -689,19 +807,20 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following values:
- <ul>
- <li><code><em>&lt;serviceName&gt;</em></code>: Replace <em>&lt;serviceName&gt;</em> with a name for the service to apply proxy-buffers. </li>
- <li><code><em>&lt;number_of_buffers&gt;</em></code>: Replace <em>&lt;number_of_buffers&gt;</em> with a number, such as <em>2</em>.</li>
- <li><code><em>&lt;size&gt;</em></code>: Enter the size of each buffer in kilobytes (k or K), such as <em>1K</em>.</li>
- </ul>
- </td>
+ <td><code>serviceName</code></td>
+ <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name for a service to apply proxy-buffers.</td>
+ </tr>
+ <tr>
+ <td><code>number_of_buffers</code></td>
+ <td>Replace <code>&lt;<em>number_of_buffers</em>&gt;</code> with a number, such as <em>2</em>.</td>
+ </tr>
+ <tr>
+ <td><code>size</code></td>
+ <td>Replace <code>&lt;<em>size</em>&gt;</code> with the size of each buffer in kilobytes (k or K), such as <em>1K</em>.</td>
  </tr>
  </tbody>
  </table>
- </dd>
- </dl>
+ </dd></dl>
 
 <br />
 
@@ -728,7 +847,7 @@ kind: Ingress
 metadata:
  name: proxy-ingress
  annotations:
-   ingress.bluemix.net/proxy-buffer-size: "serviceName=&lt;serviceName&gt; size=&lt;size&gt;"
+   ingress.bluemix.net/proxy-buffer-size: "serviceName=&lt;myservice&gt; size=&lt;size&gt;"
 spec:
  tls:
  - hosts:
@@ -750,12 +869,12 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following values:<ul>
- <li><code><em>&lt;serviceName&gt;</em></code>: Replace <em>&lt;serviceName&gt;</em> with a name of the service to apply proxy-busy-buffers-size.</li>
- <li><code><em>&lt;size&gt;</em></code>: Enter the size of each buffer in kilobytes (k or K), such as <em>1K</em>.</li>
- </ul>
- </td>
+ <td><code>serviceName</code></td>
+ <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of a service to apply proxy-buffers-size.</td>
+ </tr>
+ <tr>
+ <td><code>size</code></td>
+ <td>Replace <code>&lt;<em>size</em>&gt;</code> with the size of each buffer in kilobytes (k or K), such as <em>1K</em>.</td>
  </tr>
  </tbody></table>
 
@@ -803,20 +922,21 @@ spec:
          serviceName: myservice
          servicePort: 8080
          </code></pre>
+
 <table>
- <thead>
- <th colspan=2><img src="images/idea.png" alt="Idea icon"/> Understanding the YAML file components</th>
- </thead>
- <tbody>
- <tr>
- <td><code>annotations</code></td>
- <td>Replace the following values:<ul>
- <li><code><em>&lt;serviceName&gt;</em></code>: Replace <em>&lt;serviceName&gt;</em> with a name of the service to apply proxy-busy-buffers-size.</li>
- <li><code><em>&lt;size&gt;</em></code>: Enter the size of each buffer in kilobytes (k or K), such as <em>1K</em>.</li>
- </ul>
- </td>
- </tr>
- </tbody></table>
+<thead>
+<th colspan=2><img src="images/idea.png" alt="Idea icon"/> Understanding the YAML file components</th>
+</thead>
+<tbody>
+<tr>
+<td><code>serviceName</code></td>
+<td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of a service to apply proxy-busy-buffers-size.</td>
+</tr>
+<tr>
+<td><code>size</code></td>
+<td>Replace <code>&lt;<em>size</em>&gt;</code> with the size of each buffer in kilobytes (k or K), such as <em>1K</em>.</td>
+</tr>
+</tbody></table>
 
  </dd>
  </dl>
@@ -851,19 +971,19 @@ metadata:
   name: myingress
   annotations:
     ingress.bluemix.net/proxy-add-headers: |
-      serviceName=&lt;service_name1&gt; {
-      &lt;header1> &lt;value1&gt;;
-      &lt;header2> &lt;value2&gt;;
+      serviceName=&lt;myservice1&gt; {
+      &lt;header1&gt; &lt;value1&gt;;
+      &lt;header2&gt; &lt;value2&gt;;
       }
-      serviceName=&lt;service_name2&gt; {
+      serviceName=&lt;myservice2&gt; {
       &lt;header3&gt; &lt;value3&gt;;
       }
     ingress.bluemix.net/response-add-headers: |
-      serviceName=&lt;service_name1&gt; {
+      serviceName=&lt;myservice1&gt; {
       "&lt;header1&gt;: &lt;value1&gt;";
       "&lt;header2&gt;: &lt;value2&gt;";
       }
-      serviceName=&lt;service_name1&gt; {
+      serviceName=&lt;myservice2&gt; {
       "&lt;header3&gt;: &lt;value3&gt;";
       }
 spec:
@@ -877,11 +997,11 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: &lt;service_name1&gt;
+          serviceName: &lt;myservice1&gt;
           servicePort: 8080
       - path: /myapp
         backend:
-          serviceName: &lt;service_name2&gt;
+          serviceName: &lt;myservice2&gt;
           servicePort: 80</code></pre>
 
  <table>
@@ -890,12 +1010,16 @@ spec:
   </thead>
   <tbody>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;service_name&gt;</em></code>: The name of the Kubernetes service that you created for your app.</li>
-  <li><code><em>&lt;header&gt;</em></code>: The key of the header information to add to the client request or client response.</li>
-  <li><code><em>&lt;value&gt;</em></code>: The value of the header information to add to the client request or client response.</li>
-  </ul></td>
+  <td><code>service_name</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app.</td>
+  </tr>
+  <tr>
+  <td><code>&lt;header&gt;</code></td>
+  <td>The key of the header information to add to the client request or client response.</td
+  </tr>
+  <tr>
+  <td><code>&lt;value&gt;</code></td>
+  <td>The value of the header information to add to the client request or client response.</td>
   </tr>
   </tbody></table>
  </dd></dl>
@@ -922,11 +1046,11 @@ Remove header information that is included in the client response from the back-
    name: myingress
    annotations:
      ingress.bluemix.net/response-remove-headers: |
-       serviceName=&lt;service_name1&gt; {
+       serviceName=&lt;myservice1&gt; {
        "&lt;header1&gt;";
        "&lt;header2&gt;";
        }
-       serviceName=&lt;service_name2&gt; {
+       serviceName=&lt;myservice2&gt; {
        "&lt;header3&gt;";
        }
  spec:
@@ -940,11 +1064,11 @@ Remove header information that is included in the client response from the back-
        paths:
        - path: /
          backend:
-           serviceName: &lt;service_name1&gt;
+           serviceName: &lt;myservice1&gt;
            servicePort: 8080
        - path: /myapp
          backend:
-           serviceName: &lt;service_name2&gt;
+           serviceName: &lt;myservice2&gt;
            servicePort: 80</code></pre>
 
   <table>
@@ -953,11 +1077,12 @@ Remove header information that is included in the client response from the back-
    </thead>
    <tbody>
    <tr>
-   <td><code>annotations</code></td>
-   <td>Replace the following values:<ul>
-   <li><code><em>&lt;service_name&gt;</em></code>: The name of the Kubernetes service that you created for your app.</li>
-   <li><code><em>&lt;header&gt;</em></code>: The key of the header to remove from the client response.</li>
-   </ul></td>
+   <td><code>service_name</code></td>
+   <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the Kubernetes service that you created for your app.</td>
+   </tr>
+   <tr>
+   <td><code>&lt;header&gt;</code></td>
+   <td>The key of the header to remove from the client response.</td>
    </tr>
    </tbody></table>
    </dd></dl>
@@ -973,12 +1098,12 @@ Adjust the maximum size of the body that the client can send as part of a reques
 
 <dl>
 <dt>Description</dt>
-<dd>To maintain the expected performance, the maximum client request body size is set to 1 megabyte. When a client request with a body size over the limit is sent to the Ingress application load balancer, and the client does not allow data to be divided, the application load balancer returns a 413 (Request Entity Too Large) http response to the client. A connection between the client and the application load balancer is not possible until the size of the request body is reduced. When the client allows data to be split up into multiple chunks, data is divided into packages of 1 megabyte and sent to the application load balancer.
+<dd>To maintain the expected performance, the maximum client request body size is set to 1 megabyte. When a client request with a body size over the limit is sent to the Ingress application load balancer, and the client does not allow data to be divided, the application load balancer returns a 413 (Request Entity Too Large) HTTP response to the client. A connection between the client and the application load balancer is not possible until the size of the request body is reduced. When the client allows data to be split up into multiple chunks, data is divided into packages of 1 megabyte and sent to the application load balancer.
 
 </br></br>
 You might want to increase the maximum body size because you expect client requests with a body size that is greater than 1 megabyte. For example, you want your client to be able to upload large files. Increasing the maximum request body size might impact the performance of your application load balancer because the connection to the client must stay open until the request is received.
 </br></br>
-<strong>Note:</strong> Some client web browsers cannot display the 413 http response message properly.</dd>
+<strong>Note:</strong> Some client web browsers cannot display the 413 HTTP response message properly.</dd>
 <dt>Sample Ingress resource YAML</dt>
 <dd>
 
@@ -1009,12 +1134,8 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following value:<ul>
- <li><code><em>&lt;size&gt;</em></code>: Enter the maximum size of the client response body. For example, to set it to 200 megabyte, define <strong>200m</strong>.
-
- </br></br>
- <strong>Note:</strong> You can set the size to 0 to disable the check of the client request body size.</li></ul></td>
+ <td><code>&lt;size&gt;</code></td>
+ <td>The maximum size of the client response body. For example, to set it to 200 megabyte, define <code>200m</code>.  <strong>Note:</strong> You can set the size to 0 to disable the check of the client request body size.</td>
  </tr>
  </tbody></table>
 
@@ -1071,13 +1192,16 @@ For all services, limit the request processing rate and the number of connection
   </thead>
   <tbody>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;key&gt;</em></code>: To set a global limit for incoming requests based on the location or service, use `key=location`. To set a global limit for incoming requests based on the header, use `X-USER-ID key==$http_x_user_id`.</li>
-  <li><code><em>&lt;rate&gt;</em></code>: The processing rate. To define a rate per second, use r/s: <code>10r/s</code>. To define a rate per minute, use r/m: <code>50r/m</code>.</li>
-  <li><code><em>&lt;conn&gt;</em></code>: The number of connections.</li>
-  </ul>
-  </td>
+  <td><code>key</code></td>
+  <td>To set a global limit for incoming requests based on the location or service, use `key=location`. To set a global limit for incoming requests based on the header, use `X-USER-ID key==$http_x_user_id`.</td>
+  </tr>
+  <tr>
+  <td><code>rate</code></td>
+  <td>Replace <code>&lt;<em>rate</em>&gt;</code> with the processing rate. Enter a value as a rate per second (r/s) or rate per minute (r/m). Example: <code>50r/m</code>.</td>
+  </tr>
+  <tr>
+  <td><code>number-of_connections</code></td>
+  <td>Replace <code>&lt;<em>conn</em>&gt;</code> with the number of connections.</td>
   </tr>
   </tbody></table>
 
@@ -1109,7 +1233,7 @@ Limit the request processing rate and the number of connections for specific ser
  metadata:
   name: myingress
   annotations:
-    ingress.bluemix.net/service-rate-limit: "serviceName=&lt;service_name&gt; key=&lt;key&gt; rate=&lt;rate&gt; conn=&lt;number_of_connections&gt;"
+    ingress.bluemix.net/service-rate-limit: "serviceName=&lt;myservice&gt; key=&lt;key&gt; rate=&lt;rate&gt; conn=&lt;number_of_connections&gt;"
  spec:
   tls:
   - hosts:
@@ -1130,14 +1254,20 @@ Limit the request processing rate and the number of connections for specific ser
   </thead>
   <tbody>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;serviceName&gt;</em></code>: The name of the Ingress resource.</li>
-  <li><code><em>&lt;key&gt;</em></code>: To set a global limit for incoming requests based on the location or service, use `key=location`. To set a global limit for incoming requests based on the header, use `X-USER-ID key==$http_x_user_id`.</li>
-  <li><code><em>&lt;rate&gt;</em></code>: The processing rate. The processing rate. To define a rate per second, use r/s: <code>10r/s</code>. To define a rate per minute, use r/m: <code>50r/m</code>.</li>
-  <li><code><em>&lt;conn&gt;</em></code>: The number of connections.</li>
-  </ul>
-  </td>
+  <td><code>serviceName</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the service for which you want to limit the processing rate.</li>
+  </tr>
+  <tr>
+  <td><code>key</code></td>
+  <td>To set a global limit for incoming requests based on the location or service, use `key=location`. To set a global limit for incoming requests based on the header, use `X-USER-ID key==$http_x_user_id`.</td>
+  </tr>
+  <tr>
+  <td><code>rate</code></td>
+  <td>Replace <code>&lt;<em>rate</em>&gt;</code> with the processing rate. To define a rate per second, use r/s: <code>10r/s</code>. To define a rate per minute, use r/m: <code>50r/m</code>.</td>
+  </tr>
+  <tr>
+  <td><code>number-of_connections</code></td>
+  <td>Replace <code>&lt;<em>conn</em>&gt;</code> with the number of connections.</td>
   </tr>
   </tbody></table>
   </dd>
@@ -1147,8 +1277,8 @@ Limit the request processing rate and the number of connections for specific ser
 
 
 
-## TLS/SSL authentication annotations
-{: #tls-ssl-auth}
+## HTTPS and TLS/SSL authentication annotations
+{: #https-auth}
 
 
 ### Custom HTTP and HTTPS ports (custom-port)
@@ -1172,7 +1302,7 @@ kind: Ingress
 metadata:
  name: myingress
  annotations:
-   ingress.bluemix.net/custom-port: "protocol=&lt;protocol1&gt; port=&lt;port1&gt;;protocol=&lt;protocol2&gt;port=&lt;port2&gt;"
+   ingress.bluemix.net/custom-port: "protocol=&lt;protocol1&gt; port=&lt;port1&gt;;protocol=&lt;protocol2&gt; port=&lt;port2&gt;"
 spec:
  tls:
  - hosts:
@@ -1193,13 +1323,12 @@ spec:
  </thead>
  <tbody>
  <tr>
- <td><code>annotations</code></td>
- <td>Replace the following values:<ul>
- <li><code><em>&lt;protocol&gt;</em></code>: Enter <strong>http</strong> or <strong>https</strong> to change the default port for incoming HTTP or HTTPS network traffic.</li>
- <li><code><em>&lt;port&gt;</em></code>: Enter the port number that you want to use for incoming HTTP or HTTPS network traffic.</li>
- </ul>
- <p><strong>Note:</strong> When a custom port is specified for either HTTP or HTTPS, the default ports are no longer valid for both HTTP and HTTPS. For example, to change the default port for HTTPS to 8443, but use the default port for HTTP, you must set custom ports for both: <code>custom-port: "protocol=http port=80; protocol=https port=8443"</code>.</p>
- </td>
+ <td><code>&lt;protocol&gt;</code></td>
+ <td>Enter <strong>http</strong> or <strong>https</strong> to change the default port for incoming HTTP or HTTPS network traffic.</td>
+ </tr>
+ <tr>
+ <td><code>&lt;port&gt;</code></td>
+ <td>Enter the port number that you want to use for incoming HTTP or HTTPS network traffic.  <p><strong>Note:</strong> When a custom port is specified for either HTTP or HTTPS, the default ports are no longer valid for both HTTP and HTTPS. For example, to change the default port for HTTPS to 8443, but use the default port for HTTP, you must set custom ports for both: <code>custom-port: "protocol=http port=80; protocol=https port=8443"</code>.</p></td>
  </tr>
  </tbody></table>
 
@@ -1254,10 +1383,11 @@ Convert insecure HTTP client requests to HTTPS.
 
 <dl>
 <dt>Description</dt>
-<dd>You set up your Ingress application load balancer to secure your domain with the IBM-provided TLS certificate or your custom TLS certificate. Some users might try to access your apps by using an insecure http request to your application load balancer domain, for example <code>http://www.myingress.com</code>, instead of using <code>https</code>. You can use the redirect annotation to always convert insecure http requests to https. If you do not use this annotation, insecure http requests are not converted into https requests by default and might expose unencrypted confidential information to the public.
+<dd>You set up your Ingress application load balancer to secure your domain with the IBM-provided TLS certificate or your custom TLS certificate. Some users might try to access your apps by using an insecure http request to your application load balancer domain, for example <code>http://www.myingress.com</code>, instead of using <code>https</code>. You can use the redirect annotation to always convert insecure HTTP requests to HTTPS. If you do not use this annotation, insecure HTTP requests are not converted into HTTPS requests by default and might expose unencrypted confidential information to the public.
 
 </br></br>
-Redirecting http requests to https is disabled by default.</dd>
+Redirecting HTTP requests to HTTPS is disabled by default.</dd>
+
 <dt>Sample Ingress resource YAML</dt>
 <dd>
 <pre class="codeblock">
@@ -1316,21 +1446,21 @@ kind: Ingress
 metadata:
 name: myingress
 annotations:
-  ingress.bluemix.net/mutual-auth: "port=&lt;port&gt; secretName=&lt;secretName&gt; serviceName=&lt;service1&gt;,&lt;service2&gt;"
+  ingress.bluemix.net/mutual-auth: "secretName=&lt;mysecret&gt; port=&lt;port&gt; serviceName=&lt;servicename1&gt;,&lt;servicename2&gt;"
 spec:
-tls:
-- hosts:
-  - mydomain
-  secretName: mytlssecret
-rules:
-- host: mydomain
-  http:
-    paths:
-    - path: /
-      backend:
-        serviceName: myservice
-        servicePort: 8080
-        </code></pre>
+  tls:
+  - hosts:
+    - mydomain
+    secretName: mytlssecret
+  rules:
+  - host: mydomain
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: myservice
+          servicePort: 8080
+          </code></pre>
 
 <table>
 <thead>
@@ -1338,13 +1468,16 @@ rules:
 </thead>
 <tbody>
 <tr>
-<td><code>annotations</code></td>
-<td>Replace the following values:<ul>
-<li><code><em>&lt;serviceName&gt;</em></code>: The name of one or more Ingress resources. This parameter is optional.</li>
-<li><code><em>&lt;secretName&gt;</em></code>: Replace <em>&lt;secret_name&gt;</em> with a name for the secret resource.</li>
-<li><code><em>&lt;port&gt;</em></code>: Enter the port number.</li>
-</ul>
-</td>
+<td><code>secretName</code></td>
+<td>Replace <code>&lt;<em>mysecret</em>&gt;</code> with a name for the secret resource.</td>
+</tr>
+<tr>
+<td><code>&lt;port&gt;</code></td>
+<td>The application load balancer port number.</td>
+</tr>
+<tr>
+<td><code>&lt;serviceName&gt;</code></td>
+<td>The name of one or more Ingress resources. This parameter is optional.</td>
 </tr>
 </tbody></table>
 
@@ -1379,19 +1512,19 @@ kind: Ingress
 metadata:
   name: &lt;myingressname&gt;
   annotations:
-    ingress.bluemix.net/ssl-services: ssl-service=&lt;service1&gt; [ssl-secret=&lt;service1-ssl-secret&gt;];ssl-service=&lt;service2&gt; [ssl-secret=&lt;service2-ssl-secret&gt;]
+    ingress.bluemix.net/ssl-services: "ssl-service=&lt;myservice1&gt; [ssl-secret=&lt;service1-ssl-secret&gt;];ssl-service=&lt;myservice2&gt; [ssl-secret=&lt;service2-ssl-secret&gt;]
 spec:
   rules:
-  - host: &lt;ibmdomain&gt;
+  - host: mydomain
     http:
       paths:
-      - path: /&lt;myservicepath1&gt;
+      - path: /
         backend:
-          serviceName: &lt;myservice1&gt;
+          serviceName: myservice1
           servicePort: 8443
-      - path: /&lt;myservicepath2&gt;
+      - path: /
         backend:
-          serviceName: &lt;myservice2&gt;
+          serviceName: myservice2
           servicePort: 8444</code></pre>
 
 <table>
@@ -1400,43 +1533,12 @@ spec:
   </thead>
   <tbody>
   <tr>
-  <td><code>name</code></td>
-  <td>Replace <em>&lt;myingressname&gt;</em> with a name for your Ingress resource.</td>
+  <td><code>ssl-service</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the service that represents your app. Traffic is encrypted from application load balancer to this app.</td>
   </tr>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;myservice&gt;</em></code>: Enter the name of the service that represents your app. Traffic is encrypted from application load balancer to this app.</li>
-  <li><code><em>&lt;ssl-secret&gt;</em></code>: Enter the secret for the service. This parameter is optional. If the parameter is provided, the value must contain the key and the certificate that your app is expecting from the client.  </li></ul>
-  </td>
-  </tr>
-  <tr>
-  <td><code>rules/host</code></td>
-  <td>Replace <em>&lt;ibmdomain&gt;</em> with the IBM-provided <strong>Ingress subdomain</strong> name.
-  <br><br>
-  <strong>Note:</strong> To avoid failures during Ingress creation, do not use * for your host or leave the host property empty.</td>
-  </tr>
-  <tr>
-  <td><code>rules/path</code></td>
-  <td>Replace <em>&lt;myservicepath&gt;</em> with a slash or the unique path that your app is listening on, so that network traffic can be forwarded to the app.
-
-  </br>
-  For every Kubernetes service, you can define an individual path that is appended to the IBM-provided domain to create a unique path to your app, for example <code>ingress_domain/myservicepath1</code>. When you enter this route into a web browser, network traffic is routed to the application load balancer. The application load balancer looks up the associated service and sends network traffic to the service and to the pods where the app is running by using the same path. The app must be set up to listen on this path in order to receive incoming network traffic.
-
-  </br></br>
-  Many apps do not listen on a specific path but use the root path and a specific port. In this case, define the root path as <code>/</code> and do not specify an individual path for your app.
-  </br>
-  Examples: <ul><li>For <code>http://ingress_host_name/</code>, enter <code>/</code> as the path.</li><li>For <code>http://ingress_host_name/myservicepath</code>, enter <code>/myservicepath</code> as the path.</li></ul>
-  </br>
-  <strong>Tip:</strong> To configure your Ingress to listen on a path that is different to the one that your app listens on, you can use the <a href="#rewrite-path" target="_blank">rewrite annotation</a> to establish proper routing to your app.</td>
-  </tr>
-  <tr>
-  <td><code>serviceName</code></td>
-  <td>Replace <em>&lt;myservice&gt;</em> with the name of the service that you used when you created the Kubernetes service for your app.</td>
-  </tr>
-  <tr>
-  <td><code>servicePort</code></td>
-  <td>The port that your service listens to. Use the same port that you defined when you created the Kubernetes service for your app.</td>
+  <td><code>ssl-secret</code></td>
+  <td>Replace <code>&lt;<em>service-ssl-secret</em>&gt;</code> with the secret for the service. This parameter is optional. If the parameter is provided, the value must contain the key and the certificate that your app is expecting from the client.</td>
   </tr>
   </tbody></table>
 
@@ -1472,25 +1574,26 @@ metadata:
   name: &lt;myingressname&gt;
   annotations:
     ingress.bluemix.net/ssl-services: |
-      ssl-service=&lt;service1&gt; ssl-secret=&lt;service1-ssl-secret&gt;;
-      ssl-service=&lt;service2&gt; ssl-secret=&lt;service2-ssl-secret&gt;
+      ssl-service=&lt;myservice1&gt; ssl-secret=&lt;service1-ssl-secret&gt;;
+      ssl-service=&lt;myservice2&gt; ssl-secret=&lt;service2-ssl-secret&gt;
 spec:
   tls:
   - hosts:
-    - &lt;ibmdomain&gt;
-    secretName: &lt;secret_name&gt;
+    - mydomain
+    secretName: mysecret
   rules:
-  - host: &lt;ibmdomain&gt;
+  - host: mydomain
     http:
       paths:
-      - path: /&lt;myservicepath1&gt;
+      - path: /
         backend:
-          serviceName: &lt;myservice1&gt;
+          serviceName: myservice1
           servicePort: 8443
-      - path: /&lt;myservicepath2&gt;
+      - path: /
         backend:
-          serviceName: &lt;myservice2&gt;
-          servicePort: 8444</code></pre>
+          serviceName: myservice2
+          servicePort: 8444
+          </code></pre>
 
 <table>
   <thead>
@@ -1498,47 +1601,12 @@ spec:
   </thead>
   <tbody>
   <tr>
-  <td><code>name</code></td>
-  <td>Replace <em>&lt;myingressname&gt;</em> with a name for your Ingress resource.</td>
+  <td><code>ssl-service</code></td>
+  <td>Replace <code>&lt;<em>myservice</em>&gt;</code> with the name of the service that represents your app. Traffic is encrypted from application load balancer to this app.</td>
   </tr>
   <tr>
-  <td><code>annotations</code></td>
-  <td>Replace the following values:<ul>
-  <li><code><em>&lt;service&gt;</em></code>: Enter the name of the service.</li>
-  <li><code><em>&lt;service-ssl-secret&gt;</em></code>: Enter the secret for the service.</li></ul>
-  </td>
-  </tr>
-  <tr>
-  <td><code>tls/host</code></td>
-  <td>Replace <em>&lt;ibmdomain&gt;</em> with the IBM-provided <strong>Ingress subdomain</strong> name.
-  <br><br>
-  <strong>Note:</strong> To avoid failures during Ingress creation, do not use * for your host or leave the host property empty.</td>
-  </tr>
-  <tr>
-  <td><code>tls/secretName</code></td>
-  <td>Replace <em>&lt;secret_name&gt;</em> with the name of the secret that holds your certificate and, for mutual authentication, key.
-  </tr>
-  <tr>
-  <td><code>rules/path</code></td>
-  <td>Replace <em>&lt;myservicepath&gt;</em> with a slash or the unique path that your app is listening on, so that network traffic can be forwarded to the app.
-
-  </br>
-  For every Kubernetes service, you can define an individual path that is appended to the IBM-provided domain to create a unique path to your app, for example <code>ingress_domain/myservicepath1</code>. When you enter this route into a web browser, network traffic is routed to the application load balancer. The application load balancer looks up the associated service, and sends network traffic to the service and to the pods where the app is running by using the same path. The app must be set up to listen on this path in order to receive incoming network traffic.
-
-  </br></br>
-  Many apps do not listen on a specific path, but use the root path and a specific port. In this case, define the root path as <code>/</code> and do not specify an individual path for your app.
-  </br>
-  Examples: <ul><li>For <code>http://ingress_host_name/</code>, enter <code>/</code> as the path.</li><li>For <code>http://ingress_host_name/myservicepath</code>, enter <code>/myservicepath</code> as the path.</li></ul>
-  </br>
-  <strong>Tip:</strong> To configure your Ingress to listen on a path that is different to the one that your app listens on, you can use the <a href="#rewrite-path" target="_blank">rewrite annotation</a> to establish proper routing to your app.</td>
-  </tr>
-  <tr>
-  <td><code>serviceName</code></td>
-  <td>Replace <em>&lt;myservice&gt;</em> with the name of the service that you used when you created the Kubernetes service for your app.</td>
-  </tr>
-  <tr>
-  <td><code>servicePort</code></td>
-  <td>The port that your service listens to. Use the same port that you defined when you created the Kubernetes service for your app.</td>
+  <td><code>ssl-secret</code></td>
+  <td>Replace <code>&lt;<em>service-ssl-secret</em>&gt;</code> with the secret for the service. This parameter is optional. If the parameter is provided, the value must contain the key and the certificate that your app is expecting from the client.</td>
   </tr>
   </tbody></table>
 

--- a/cs_apps.md
+++ b/cs_apps.md
@@ -1627,7 +1627,7 @@ To configure the private application load balancer:
         </tr>
         <tr>
         <td><code>ingress.bluemix.net/ALB-ID</code></td>
-        <td>Replace <em>&lt;private_ALB_ID&gt;</em> with the ALB ID for your private Ingress controller. Run <code>bx cs albs --cluster <my_cluster></code> to find the ALB ID. For more information about this Ingress annotation, see [Application load balancer ID (ALB_ID)](cs_annotations.html#alb-id).</td>
+        <td>Replace <em>&lt;private_ALB_ID&gt;</em> with the ALB ID for your private Ingress controller. Run <code>bx cs albs --cluster <my_cluster></code> to find the ALB ID. For more information about this Ingress annotation, see [Private application load balancer routing](cs_annotations.html#alb-id).</td>
         </tr>
         <td><code>host</code></td>
         <td>Replace <em>&lt;mycustomdomain&gt;</em> with your custom domain.

--- a/cs_cli_reference.md
+++ b/cs_cli_reference.md
@@ -33,10 +33,10 @@ Refer to these commands to create and manage clusters.
  </thead>
  <tbody>
   <tr>
-    <td>[bx cs albs](#cs_albs)</td>
     <td>[bx cs alb-configure](#cs_alb_configure)</td>
     <td>[bx cs alb-get](#cs_alb_get)</td>
     <td>[bx cs alb-types](#cs_alb_types)</td>
+    <td>[bx cs albs](#cs_albs)</td>
     <td>[bx cs apiserver-config-set](#cs_apiserver_config_set)</td>
   </tr>
  <tr>
@@ -922,15 +922,15 @@ Create a logging configuration. You can use this command to forward logs for con
 <dt><code>--logsource <em>LOG_SOURCE</em></code></dt>
 <dd>The log source that you want to enable log forwarding for. Accepted values are <code>container</code>, <code>application</code>, <code>worker</code>, <code>kubernetes</code>, and <code>ingress</code>. This value is required.</dd>
 <dt><code>--namespace <em>KUBERNETES_NAMESPACE</em></code></dt>
-<dd>The Docker container namespace that you want to forward logs from. Log forwarding is not supported for the <code>ibm-system</code> and <code>kube-system</code> Kubernetes namespaces. This value is valid only for the container log source and is optional. If you do not specify a namespace, then all namespaces in the container use this configuration.</dd>
+<dd>The Kubernetes namespace that you want to forward logs from. Log forwarding is not supported for the <code>ibm-system</code> and <code>kube-system</code> Kubernetes namespaces. This value is valid only for the container log source and is optional. If you do not specify a namespace, then all namespaces in the cluster use this configuration.</dd>
 <dt><code>--hostname <em>LOG_SERVER_HOSTNAME</em></code></dt>
 <dd>When the logging type is <code>syslog</code>, the hostname or IP address of the log collector server. This value is required for <code>syslog</code>. When the logging type is <code>ibm</code>, the {{site.data.keyword.loganalysislong_notm}} ingestion URL. You can find the list of available ingestion URLs [here](/docs/services/CloudLogAnalysis/log_ingestion.html#log_ingestion_urls). If you do not specify an ingestion URL, the endpoint for the region where your cluster was created is used.</dd>
 <dt><code>--port <em>LOG_SERVER_PORT</em></code></dt>
 <dd>The port of the log collector server. This value is optional. If you do not specify a port, then the standard port <code>514</code> is used for <code>syslog</code> and the standard port <code>9091</code> is used for <code>ibm</code>.</dd>
 <dt><code>--space <em>CLUSTER_SPACE</em></code></dt>
-<dd>The name of the space that you want to send logs to. This value is valid only for log type <code>ibm</code> and is optional. If you do not specify a space, logs are sent to the account level.</dd>
+<dd>The name of the Cloud Foundry space that you want to send logs to. This value is valid only for log type <code>ibm</code> and is optional. If you do not specify a space, logs are sent to the account level.</dd>
 <dt><code>--org <em>CLUSTER_ORG</em></code></dt>
-<dd>The name of the org that the space is in. This value is valid only for log type <code>ibm</code> and is required if you specified a space.</dd>
+<dd>The name of the Cloud Foundry org that the space is in. This value is valid only for log type <code>ibm</code> and is required if you specified a space.</dd>
 <dt><code>--type <em>LOG_TYPE</em></code></dt>
 <dd>The log forwarding protocol that you want to use. Currently, <code>syslog</code> and <code>ibm</code> are supported. This value is required.</dd>
 <dt><code>--json</code></dt>
@@ -953,12 +953,12 @@ Example for log type `syslog` that fowards from a `container` log source on defa
   ```
   {: pre}
 
-  Example for log type `syslog` that forwards logs from an `ingress` source on a port different than the default:
+Example for log type `syslog` that forwards logs from an `ingress` source on a port different than the default:
 
-    ```
-    bx cs logging-config-create my_cluster --logsource container --hostname my_hostname-or-IP --port 5514 --type syslog
-    ```
-    {: pre}
+  ```
+  bx cs logging-config-create my_cluster --logsource container --hostname my_hostname-or-IP --port 5514 --type syslog
+  ```
+  {: pre}
 
 ### bx cs logging-config-get CLUSTER [--logsource LOG_SOURCE] [--json]
 {: #cs_logging_get}
@@ -984,7 +984,7 @@ View all log forwarding configurations for a cluster, or filter logging configur
   {: pre}
 
 
-### bx cs logging-config-rm CLUSTER LOG_CONFIG_ID
+### bx cs logging-config-rm CLUSTER --id LOG_CONFIG_ID
 {: #cs_logging_rm}
 
 Deletes a log forwarding configuration. This stops log forwarding to a syslog server or to {{site.data.keyword.loganalysisshort_notm}}.
@@ -994,19 +994,19 @@ Deletes a log forwarding configuration. This stops log forwarding to a syslog se
    <dl>
    <dt><code><em>CLUSTER</em></code></dt>
    <dd>The name or ID of the cluster. This value is required.</dd>
-   <dt><code><em>LOG_CONFIG_ID</em></code></dt>
+   <dt><code>--id <em>LOG_CONFIG_ID</em></code></dt>
    <dd>The logging configuration ID that you want to remove from the log source. This value is required.</dd>
    </dl>
 
 **Example**:
 
   ```
-  bx cs logging-config-rm my_cluster f4bc77c0-ee7d-422d-aabf-a4e6b977264e
+  bx cs logging-config-rm my_cluster --id f4bc77c0-ee7d-422d-aabf-a4e6b977264e
   ```
   {: pre}
 
 
-### bx cs logging-config-update CLUSTER LOG_CONFIG_ID [--hostname LOG_SERVER_HOSTNAME_OR_IP] [--port LOG_SERVER_PORT] [--space CLUSTER_SPACE] [--org CLUSTER_ORG] --type LOG_TYPE [--json]
+### bx cs logging-config-update CLUSTER --id LOG_CONFIG_ID [--hostname LOG_SERVER_HOSTNAME_OR_IP] [--port LOG_SERVER_PORT] [--space CLUSTER_SPACE] [--org CLUSTER_ORG] --type LOG_TYPE [--json]
 {: #cs_logging_update}
 
 Update the details of a log forwarding configuration.
@@ -1016,7 +1016,7 @@ Update the details of a log forwarding configuration.
    <dl>
    <dt><code><em>CLUSTER</em></code></dt>
    <dd>The name or ID of the cluster. This value is required.</dd>
-   <dt><code><em>LOG_CONFIG_ID</em></code></dt>
+   <dt><code>--id <em>LOG_CONFIG_ID</em></code></dt>
    <dd>The logging configuration ID that you want to update. This value is required.</dd>
    <dt><code>--hostname <em>LOG_SERVER_HOSTNAME</em></code></dt>
    <dd>When the logging type is <code>syslog</code>, the hostname or IP address of the log collector server. This value is required for <code>syslog</code>. When the logging type is <code>ibm</code>, the {{site.data.keyword.loganalysislong_notm}} ingestion URL. You can find the list of available ingestion URLs [here](/docs/services/CloudLogAnalysis/log_ingestion.html#log_ingestion_urls). If you do not specify an ingestion URL, the endpoint for the region where your cluster was created is used.</dd>
@@ -1035,14 +1035,14 @@ Update the details of a log forwarding configuration.
 **Example for log type `ibm`**:
 
   ```
-  bx cs logging-config-update my_cluster f4bc77c0-ee7d-422d-aabf-a4e6b977264e --type ibm
+  bx cs logging-config-update my_cluster --id f4bc77c0-ee7d-422d-aabf-a4e6b977264e --type ibm
   ```
   {: pre}
 
 **Example for log type `syslog`**:
 
   ```
-  bx cs logging-config-update my_cluster f4bc77c0-ee7d-422d-aabf-a4e6b977264e --hostname localhost --port 5514 --type syslog
+  bx cs logging-config-update my_cluster --id f4bc77c0-ee7d-422d-aabf-a4e6b977264e --hostname localhost --port 5514 --type syslog
   ```
   {: pre}
 

--- a/cs_cluster.md
+++ b/cs_cluster.md
@@ -1340,7 +1340,7 @@ To enable log forwarding for a container, worker node, Kubernetes system compone
     </tr>
     <tr>
     <td><code><em>&lt;kubernetes_namespace&gt;</em></code></td>
-    <td>Replace <em>&lt;kubernetes_namespace&gt;</em> with the Docker container namespace that you want to forward logs from. Log forwarding is not supported for the <code>ibm-system</code> and <code>kube-system</code> Kubernetes namespaces. This value is valid only for the container log source and is optional. If you do not specify a namespace, then all namespaces in the container use this configuration.</td>
+    <td>Replace <em>&lt;kubernetes_namespace&gt;</em> with the Kubernetes namespace that you want to forward logs from. Log forwarding is not supported for the <code>ibm-system</code> and <code>kube-system</code> Kubernetes namespaces. This value is valid only for the container log source and is optional. If you do not specify a namespace, then all namespaces in the cluster use this configuration.</td>
     </tr>
     <tr>
     <td><code>--hostname <em>&lt;ingestion_URL&gt;</em></code></td>
@@ -1352,11 +1352,11 @@ To enable log forwarding for a container, worker node, Kubernetes system compone
     </tr>
     <tr>
     <td><code>--space <em>&lt;cluster_space&gt;</em></code></td>
-    <td>Replace <em>&lt;cluster_space&gt;</em> with the name of the space that you want to send logs to. If you do not specify a space, logs are sent to the account level.</td>
+    <td>Replace <em>&lt;cluster_space&gt;</em> with the name of the Cloud Foundry space that you want to send logs to. If you do not specify a space, logs are sent to the account level.</td>
     </tr>
     <tr>
     <td><code>--org <em>&lt;cluster_org&gt;</em></code></td>
-    <td>Replace <em>&lt;cluster_org&gt;</em> with the name of the org that the space is in. This value is required if you specified a space.</td>
+    <td>Replace <em>&lt;cluster_org&gt;</em> with the name of the Cloud Foundry org that the space is in. This value is required if you specified a space.</td>
     </tr>
     <tr>
     <td><code>--type ibm</code></td>
@@ -1391,7 +1391,7 @@ To enable log forwarding for a container, worker node, Kubernetes system compone
     </tr>
     <tr>
     <td><code><em>&lt;kubernetes_namespace&gt;</em></code></td>
-    <td>Replace <em>&lt;kubernetes_namespace&gt;</em> with the Docker container namespace that you want to forward logs from. Log forwarding is not supported for the <code>ibm-system</code> and <code>kube-system</code> Kubernetes namespaces. This value is valid only for the container log source and is optional. If you do not specify a namespace, then all namespaces in the container use this configuration.</td>
+    <td>Replace <em>&lt;kubernetes_namespace&gt;</em> with the Kubernetes namespace that you want to forward logs from. Log forwarding is not supported for the <code>ibm-system</code> and <code>kube-system</code> Kubernetes namespaces. This value is valid only for the container log source and is optional. If you do not specify a namespace, then all namespaces in the cluster use this configuration.</td>
     </tr>
     <tr>
     <td><code>--hostname <em>&lt;log_server_hostname_or_IP&gt;</em></code></td>
@@ -1505,7 +1505,7 @@ To change the details of a logging configuration:
 1. Update the logging configuration.
 
     ```
-    bx cs logging-config-update <my_cluster> <log_config_id> --logsource <my_log_source> --hostname <log_server_hostname_or_IP> --port <log_server_port> --space <cluster_space> --org <cluster_org> --type <logging_type>
+    bx cs logging-config-update <my_cluster> --id <log_config_id> --logsource <my_log_source> --hostname <log_server_hostname_or_IP> --port <log_server_port> --space <cluster_space> --org <cluster_org> --type <logging_type>
     ```
     {: pre}
 
@@ -1524,7 +1524,7 @@ To change the details of a logging configuration:
     <td>Replace <em>&lt;my_cluster&gt;</em> with the name or ID of the cluster.</td>
     </tr>
     <tr>
-    <td><code><em>&lt;log_config_id&gt;</em></code></td>
+    <td><code>--id <em>&lt;log_config_id&gt;</em></code></td>
     <td>Replace <em>&lt;log_config_id&gt;</em> with the ID of the log source configuration.</td>
     </tr>
     <tr>
@@ -1541,11 +1541,11 @@ To change the details of a logging configuration:
     </tr>
     <tr>
     <td><code>--space <em>&lt;cluster_space&gt;</em></code></td>
-    <td>Replace <em>&lt;cluster_space&gt;</em> with the name of the space that you want to send logs to. This value is valid only for log type <code>ibm</code> and is optional. If you do not specify a space, logs are sent to the account level.</td>
+    <td>Replace <em>&lt;cluster_space&gt;</em> with the name of the Cloud Foundry space that you want to send logs to. This value is valid only for log type <code>ibm</code> and is optional. If you do not specify a space, logs are sent to the account level.</td>
     </tr>
     <tr>
     <td><code>--org <em>&lt;cluster_org&gt;</em></code></td>
-    <td>Replace <em>&lt;cluster_org&gt;</em> with the name of the org that the space is in. This value is valid only for log type <code>ibm</code> and is required if you specified a space.</td>
+    <td>Replace <em>&lt;cluster_org&gt;</em> with the name of the Cloud Foundry org that the space is in. This value is valid only for log type <code>ibm</code> and is required if you specified a space.</td>
     </tr>
     <tr>
     <td><code>--type <em>&lt;logging_type&gt;</em></code></td>
@@ -1599,7 +1599,7 @@ Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to you
 1. Delete the logging configuration.
 
     ```
-    bx cs logging-config-rm <my_cluster> <log_config_id>
+    bx cs logging-config-rm <my_cluster> --id <log_config_id>
     ```
     {: pre}
     Replace <em>&lt;my_cluster&gt;</em> with the name of the cluster that the logging configuration is in and <em>&lt;log_config_id&gt;</em> with the ID of the log source configuration.
@@ -1616,7 +1616,13 @@ Kubernetes API audit logs capture any calls to the Kubernetes API server from yo
 #### Enabling Kubernetes API audit log forwarding
 {: #cs_audit_enable}
 
-Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to the cluster that you want to collect API server audit logs from.
+Before you begin:
+
+1. Set up a remote logging server where you can forward the logs. For example, you can [use Logstash with Kubernetes ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#use-logstash-to-collect-and-distribute-audit-events-from-webhook-backend) to collect audit events.
+
+2. [Target your CLI](cs_cli_install.html#cs_cli_configure) to the cluster that you want to collect API server audit logs from.
+
+To forward Kubernetes API audit logs:
 
 1. Set the webhook backend for the API server configuration. A webhook configuration is created based on the information you provide in this command's flags. If you do not provide any information in the flags, a default webhook configuration is used.
 
@@ -1768,7 +1774,7 @@ The {{site.data.keyword.containerlong_notm}} Autorecovery system can be deployed
 
 Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to the cluster where you want to check worker node statuses.
 
-1. Create a configuration map file that defines your checks in JSON format. For example, the following YAML file defines three checks: an HTTP check and two Kubernetes API server checks.
+1. Create a configuration map file that defines your checks in JSON format. For example, the following YAML file defines three checks: an HTTP check and two Kubernetes API server checks. **Note**: Each check needs to be defined as a unique key in the data section of the config map.
 
     ```
     kind: ConfigMap
@@ -1799,7 +1805,7 @@ Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to the
           "CooloffSeconds":1800,
           "IntervalSeconds":180,
           "TimeoutSeconds":10,
-          "Enabled":false
+          "Enabled":true
         }
       checkpod.json: |
         {
@@ -1807,78 +1813,106 @@ Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to the
           "Resource":"POD",
           "PodFailureThresholdPercent":50,
           "FailureThreshold":3,
-          "CorrectiveAction":"REBOOT",
+          "CorrectiveAction":"RELOAD",
           "CooloffSeconds":1800,
           "IntervalSeconds":180,
           "TimeoutSeconds":10,
-          "Enabled":false
+          "Enabled":true
       }
     ```
     {:codeblock}
 
-    <table>
-    <caption>Table 14. Understanding the YAML file components</caption>
-    <thead>
-    <th colspan=2><img src="images/idea.png" alt="Idea icon"/> Understanding the YAML file components</th>
-    </thead>
-    <tbody>
-    <tr>
-    <td><code>name</code></td>
-    <td>The configuration name <code>ibm-worker-recovery-checks</code> is a constant and cannot be changed.</td>
+
+<table summary="Understanding the Config Map Components">
+<caption>Table 14. Understanding the Config Map Components</caption>
+  <thead>
+    <th colspan=2><img src="images/idea.png"/>Table 14. Understanding the Config Map Components</th>
+  </thead>
+  <tbody>
+   <tr>
+      <td><code>name</code></td>
+      <td>The configuration name <code>ibm-worker-recovery-checks</code> is a constant and cannot be changed.</td>
+   </tr>
+   <tr>
+      <td><code>namespace</code></td>
+      <td>The <code>kube-system</code> namespace is a constant and cannot be changed.</td>
+   </tr>
+  <tr>
+      <td><code>checkhttp.json</code></td>
+      <td>Defines an HTTP check that checks that an HTTP server is running on every node's IP address on port 80 and returns a 200 response at path <code>/myhealth</code>. You can find the IP address for a node by running <code>kubectl get nodes</code>.
+           For example, consider two nodes in a cluster that have IP adresses of 10.10.10.1 and 10.10.10.2. In this example, two routes are checked for 200 OK responses: <code>http://10.10.10.1:80/myhealth</code> and <code>http://10.10.10.2:80/myhealth</code>.
+           The check in the above example YAML runs every 3 minutes. If it fails 3 consecutive times, the node is rebooted. This action is equivalent to running <code>bx cs worker-reboot</code>. The HTTP check is disabled until you set the <b>Enabled</b> field to <code>true</code>.</td>
     </tr>
     <tr>
-    <td><code>namespace</code></td>
-    <td>The <code>kube-system</code> namespace is a constant and cannot be changed.</td>
+      <td><code>checknode.json</code></td>
+      <td>Defines a Kubernetes API node check that checks whether each node is in the <code>Ready</code> state. The check for a specific node counts as a failure if the node is not in the <code>Ready</code> state.
+           The check in the above example YAML runs every 3 minutes. If it fails 3 consecutive times, the node is reloaded. This action is equivalent to running <code>bx cs worker-reload</code>. The node check is enabled until you set the <b>Enabled</b> field to <code>false</code> or remove the check.</td>
     </tr>
     <tr>
-    <tr>
-    <td><code>Check</code></td>
-    <td>Enter the type of check that you want Autorecovery to use. <ul><li><code>HTTP</code>: Autorecovery calls HTTP servers that run on each node to determine whether the nodes are running properly.</li><li><code>KUBEAPI</code>: Autorecovery calls the Kubernetes API server and reads the health status data reported by the worker nodes.</li></ul></td>
+      <td><code>checkpod.json</code></td>
+      <td>Defines a Kubernetes API pod check that checks the total percentage of <code>NotReady</code> pods on a node based on the total pods assigned to that node. The check for a specific node counts as a failure if the total percentage of <code>NotReady</code> pods is greater than the defined <code>PodFailureThresholdPercent</code>.
+           The check in the above example YAML runs every 3 minutes. If it fails 3 consecutive times, the node is reloaded. This action is equivalent to running <code>bx cs worker-reload</code>. The pod check is enabled until you set the <b>Enabled</b> field to <code>false</code> or remove the check.</td>
     </tr>
+  </tbody>
+</table>
+
+
+<table summary="Understanding the Components of Individual Rules">
+<caption>Table 15. Understanding the Components of Individual Rules</caption>
+  <thead>
+    <th colspan=2><img src="images/idea.png"/> Table 15. Understanding the Individual Rule Components </th>
+  </thead>
+  <tbody>
+   <tr>
+       <td><code>Check</code></td>
+       <td>Enter the type of check that you want Autorecovery to use. <ul><li><code>HTTP</code>: Autorecovery calls HTTP servers that run on each node to determine whether the nodes are running properly.</li><li><code>KUBEAPI</code>: Autorecovery calls the Kubernetes API server and reads the health status data reported by the worker nodes.</li></ul></td>
+       </tr>
+   <tr>
+       <td><code>Resource</code></td>
+       <td>When the check type is <code>KUBEAPI</code>, enter the type of resource that you want Autorecovery to check. Accepted values are <code>NODE</code> or <code>PODS</code>.</td>
+       </tr>
+   <tr>
+       <td><code>FailureThreshold</code></td>
+       <td>Enter the threshold for the number of consecutive failed checks. When this threshold is met, Autorecovery triggers the specified corrective action. For example, if the value is 3 and Autorecovery fails a configured check three consecutive times, Autorecovery triggers the corrective action that is associated with the check.</td>
+   </tr>
+   <tr>
+       <td><code>PodFailureThresholdPercent</code></td>
+       <td>When the resource type is <code>PODS</code>, enter the threshold for the percentage of pods on a worker node that can be in a [NotReady ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes) state. This percentage is based on the total number of pods that are scheduled to a worker node. When a check determines that the percentage of unhealthy pods is greater than the threshold, the check counts as one failure.</td>
+       </tr>
     <tr>
-    <td><code>Resource</code></td>
-    <td>When the check type is <code>KUBEAPI</code>, enter the type of resource that you want Autorecovery to check. Accepted values are <code>NODE</code> or <code>PODS</code>.</td>
-    <tr>
-    <td><code>FailureThreshold</code></td>
-    <td>Enter the threshold for the number of consecutive failed checks. When this threshold is met, Autorecovery triggers the specified corrective action. For example, if the value is 3 and Autorecovery fails a configured check three consecutive times, Autorecovery triggers the corrective action that is associated with the check.</td>
-    </tr>
-    <tr>
-    <td><code>PodFailureThresholdPercent</code></td>
-    <td>When the resource type is <code>PODS</code>, enter the threshold for the percentage of pods on a worker node that can be in a [NotReady ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes) state. This percentage is based on the total number of pods that are scheduled to a worker node. When a check determines that the percentage of unhealthy pods is greater than the threshold, the check counts as one failure.</td>
-    </tr>
-    <tr>
-    <td><code>CorrectiveAction</code></td>
-    <td>Enter the action to run when the failure threshold is met. A corrective action runs only while no other workers are being repaired and when this worker node is not in a cool-off period from a previous action. <ul><li><code>REBOOT</code>: Reboots the worker node.</li><li><code>RELOAD</code>: Reloads all of the necessary configurations for the worker node from a clean OS.</li></ul></td>
-    </tr>
-    <tr>
-    <td><code>CooloffSeconds</code></td>
-    <td>Enter the number of seconds Autorecovery must wait to issue another corrective action for a node that was already issued a corrective action. The cooloff period starts at the time a corrective action is issued.</td>
-    </tr>
-    <tr>
-    <td><code>IntervalSeconds</code></td>
-    <td>Enter the number of seconds in between consecutive checks. For example, if the value is 180, Autorecovery runs the check on each node every 3 minutes.</td>
-    </tr>
-    <tr>
-    <td><code>TimeoutSeconds</code></td>
-    <td>Enter the maximum number of seconds that a check call to the database takes before Autorecovery terminates the call operation. The value for <code>TimeoutSeconds</code> must be less than the value for <code>IntervalSeconds</code>.</td>
-    </tr>
-    <tr>
-    <td><code>Port</code></td>
-    <td>When the check type is <code>HTTP</code>, enter the port that the HTTP server must bind to on the worker nodes. This port must be exposed on the IP of every worker node in the cluster. Autorecovery requires a constant port number across all nodes for checking servers. Use [DaemonSets ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)when deploying a custom server into a cluster.</td>
-    </tr>
-    <tr>
-    <td><code>ExpectedStatus</code></td>
-    <td>When the check type is <code>HTTP</code>, enter the HTTP server status that you expect to be returned from the check. For example, a value of 200 indicates that you expect an <code>OK</code> response from the server.</td>
-    </tr>
-    <tr>
-    <td><code>Route</code></td>
-    <td>When the check type is <code>HTTP</code>, enter the path that is requested from the HTTP server. This value is typically the metrics path for the server that is running on all of the worker nodes.</td>
-    </tr>
-    <tr>
-    <td><code>Enabled</code></td>
-    <td>Enter <code>true</code> to enable the check or <code>false</code> to disable the check.</td>
-    </tr>
-    </tbody></table>
+          <td><code>CorrectiveAction</code></td>
+          <td>Enter the action to run when the failure threshold is met. A corrective action runs only while no other workers are being repaired and when this worker node is not in a cool-off period from a previous action. <ul><li><code>REBOOT</code>: Reboots the worker node.</li><li><code>RELOAD</code>: Reloads all of the necessary configurations for the worker node from a clean OS.</li></ul></td>
+          </tr>
+      <tr>
+          <td><code>CooloffSeconds</code></td>
+          <td>Enter the number of seconds Autorecovery must wait to issue another corrective action for a node that was already issued a corrective action. The cooloff period starts at the time a corrective action is issued.</td>
+          </tr>
+      <tr>
+          <td><code>IntervalSeconds</code></td>
+          <td>Enter the number of seconds in between consecutive checks. For example, if the value is 180, Autorecovery runs the check on each node every 3 minutes.</td>
+          </tr>
+      <tr>
+          <td><code>TimeoutSeconds</code></td>
+          <td>Enter the maximum number of seconds that a check call to the database takes before Autorecovery terminates the call operation. The value for <code>TimeoutSeconds</code> must be less than the value for <code>IntervalSeconds</code>.</td>
+          </tr>
+      <tr>
+          <td><code>Port</code></td>
+          <td>When the check type is <code>HTTP</code>, enter the port that the HTTP server must bind to on the worker nodes. This port must be exposed on the IP of every worker node in the cluster. Autorecovery requires a constant port number across all nodes for checking servers. Use [DaemonSets ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)when deploying a custom server into a cluster.</td>
+          </tr>
+      <tr>
+          <td><code>ExpectedStatus</code></td>
+          <td>When the check type is <code>HTTP</code>, enter the HTTP server status that you expect to be returned from the check. For example, a value of 200 indicates that you expect an <code>OK</code> response from the server.</td>
+          </tr>
+      <tr>
+          <td><code>Route</code></td>
+          <td>When the check type is <code>HTTP</code>, enter the path that is requested from the HTTP server. This value is typically the metrics path for the server that is running on all of the worker nodes.</td>
+          </tr>
+      <tr>
+          <td><code>Enabled</code></td>
+          <td>Enter <code>true</code> to enable the check or <code>false</code> to disable the check.</td>
+          </tr>
+  </tbody>
+</table>
 
 2. Create the configuration map in your cluster.
 

--- a/cs_security.md
+++ b/cs_security.md
@@ -634,7 +634,7 @@ You can choose between Calico and native Kubernetes capabilities to create netwo
 
 <ul>
   <li>[Kubernetes network policies ![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/concepts/services-networking/network-policies/): Some basic options are provided, such as specifying which pods can communicate with each other. Incoming network traffic can be allowed or blocked for a protocol and port. This traffic can be filtered based on the labels and Kubernetes namespaces of the pod that is trying to connect to other pods.</br>These policies can be applied by using `kubectl` commands or the Kubernetes APIs. When these policies are applied, they are converted into Calico network policies and Calico enforces these policies.</li>
-  <li>[Calico network policies ![External link icon](../icons/launch-glyph.svg "External link icon")](http://docs.projectcalico.org/v2.4/getting-started/kubernetes/tutorials/advanced-policy): These policies are a superset of the Kubernetes network policies and enhance the native Kubernetes capabilities with the following features.</li>
+  <li>[Calico network policies ![External link icon](../icons/launch-glyph.svg "External link icon")](http://docs.projectcalico.org/v2.6/getting-started/kubernetes/tutorials/advanced-policy): These policies are a superset of the Kubernetes network policies and enhance the native Kubernetes capabilities with the following features.</li>
     <ul><ul><li>Allow or block network traffic on specific network interfaces, not only Kubernetes pod traffic.</li>
     <li>Allow or block incoming (ingress) and outgoing (egress) network traffic.</li>
     <li>[Block incoming (ingress) traffic to LoadBalancer or NodePort Kubernetes services](#cs_block_ingress).</li>
@@ -899,7 +899,7 @@ To add network policies:
 
 4.  Create the Calico network policies to allow or block traffic.
 
-    1.  Define your [Calico network policy ![External link icon](../icons/launch-glyph.svg "External link icon")](http://docs.projectcalico.org/v2.1/reference/calicoctl/resources/policy) by creating a configuration script (.yaml). These configuration files include the selectors that describe what pods, namespaces, or hosts that these policies apply to. Refer to these [sample Calico policies ![External link icon](../icons/launch-glyph.svg "External link icon")](http://docs.projectcalico.org/v2.0/getting-started/kubernetes/tutorials/advanced-policy) to help you create your own.
+    1.  Define your [Calico network policy ![External link icon](../icons/launch-glyph.svg "External link icon")](http://docs.projectcalico.org/v2.6/reference/calicoctl/resources/policy) by creating a configuration script (.yaml). These configuration files include the selectors that describe what pods, namespaces, or hosts that these policies apply to. Refer to these [sample Calico policies ![External link icon](../icons/launch-glyph.svg "External link icon")](http://docs.projectcalico.org/v2.6/getting-started/kubernetes/tutorials/advanced-policy) to help you create your own.
 
     2.  Apply the policies to the cluster.
         -   Linux and OS X:
@@ -936,7 +936,7 @@ Some common uses for Calico `preDNAT` network policies:
 The `preDNAT` network policies are useful because default Kubernetes and Calico policies are difficult to apply to protecting Kubernetes NodePort and LoadBalancer services due to the DNAT iptables rules generated for these services.
 
 Calico `preDNAT` network policies generate iptables rules based on a [Calico
-network policy resource ![External link icon](../icons/launch-glyph.svg "External link icon")](https://docs.projectcalico.org/v2.4/reference/calicoctl/resources/policy).
+network policy resource ![External link icon](../icons/launch-glyph.svg "External link icon")](https://docs.projectcalico.org/v2.6/reference/calicoctl/resources/policy).
 
 1. Define a Calico `preDNAT` network policy for ingress access to Kubernetes services.
 


### PR DESCRIPTION
This PR includes the following changes:
Merge pull request #839 from lisowski/defaultenable
Merge pull request #844 from alchemy-containers/rlg-annotations-variables
added id flag
Merge pull request #841 from alchemy-containers/bpratt-logging-config
Testing nofollow <a> attribute
Merge pull request #854 from alchemy-containers/rlg-annotations-variables
typos
removed extraneous row
Added prereq for api server audit logs
Merge pull request #858 from kgurudut/master
calico policy v2.6 link fix
calico policy v2.6 links