### PR TITLE
Includes Merge pull request #1482 from alchemy-containers/name-reuse and more...

### DIFF
--- a/cs_annotations.md
+++ b/cs_annotations.md
@@ -1068,7 +1068,7 @@ Set the maximum number of idle keepalive connections to the upstream server of a
     </tr>
     <tr>
     <td><code>serviceName</code></td>
-    <td>Replace <code><em>&lt;myservice&gt</em></code> with the name of the Kubernetes service that you created for your app. This field is optional. If a service name is not included, then the annotation is enabled for all services.  If a service name is included, then the annotation is enabled only for that service. Separate multiple services with a semi-colon (;).</td>
+    <td>Replace <code><em>&lt;myservice&gt;</em></code> with the name of the Kubernetes service that you created for your app. This field is optional. If a service name is not included, then the annotation is enabled for all services.  If a service name is included, then the annotation is enabled only for that service. Separate multiple services with a semi-colon (;).</td>
     </tr>
     </tbody></table>
     </dd>

--- a/cs_clusters.md
+++ b/cs_clusters.md
@@ -567,6 +567,13 @@ When you delete a cluster, you are also deleting resources on the cluster, inclu
     3.  Follow the prompts and choose whether to delete cluster resources.
 
 When you remove a cluster, you can choose to remove the portable subnets and persistent storage associated with it:
-- Subnets are used to assign portable public IP addresses to load balancer services or your Ingress application load balancer. If you keep them, you can reuse them in a new cluster or manually delete them later from your IBM Cloud infrastructure (SoftLayer) portfolio.
+- Subnets are used to assign portable public IP addresses to load balancer services or your Ingress application load balancer. If you keep them, you can [reuse them in a new cluster](cs_subnets.html#custom) or manually delete them later from your IBM Cloud infrastructure (SoftLayer) portfolio.
 - If you created a persistent volume claim by using an [existing file share](cs_storage.html#existing), then you cannot delete the file share when you delete the cluster. You must manually delete the file share later from your IBM Cloud infrastructure (SoftLayer) portfolio.
 - Persistent storage provides high availability for your data. If you delete it, you cannot recover your data.
+
+**Tip**: After it is no longer listed in the available clusters list, you can reuse the name of a removed cluster.
+
+  ```
+  bx cs clusters
+  ```
+  {: pre}

--- a/cs_subnets.md
+++ b/cs_subnets.md
@@ -83,13 +83,20 @@ To create a subnet in an IBM Cloud infrastructure (SoftLayer) account and make i
 <br />
 
 
-## Adding custom and existing subnets to Kubernetes clusters
+## Adding or reusing custom and existing subnets in Kubernetes clusters
 {: #custom}
 
-You can add existing portable public or private subnets to your Kubernetes cluster.
+You can add existing portable public or private subnets to your Kubernetes cluster or reuse subnets from a deleted cluster.
 {:shortdesc}
 
-Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to your cluster.
+Before you begin, 
+- [Target your CLI](cs_cli_install.html#cs_cli_configure) to your cluster.
+- To reuse subnets from a cluster that you no longer need, delete the unneeded cluster. When prompted, choose to keep the subnets. Otherwise, the subnets are deleted within 24 hours.
+
+   ```
+   bx cs cluster-rm CLUSTER
+   ```
+   {: pre}
 
 To use an existing subnet in your IBM Cloud infrastructure (SoftLayer) portfolio with custom firewall rules or available IP addresses:
 
@@ -126,7 +133,7 @@ To use an existing subnet in your IBM Cloud infrastructure (SoftLayer) portfolio
     ```
     {: screen}
 
-3.  Create a cluster by using the location and VLAN ID that you identified. Include the `--no-subnet` flag to prevent a new portable public IP subnet and a new portable private IP subnet from being created automatically.
+3.  Create a cluster by using the location and VLAN ID that you identified. To reuse an existing subnet, include the `--no-subnet` flag to prevent a new portable public IP subnet and a new portable private IP subnet from being created automatically.
 
     ```
     bx cs cluster-create --location dal10 --machine-type u2c.2x4 --no-subnet --public-vlan 1901230 --private-vlan 1900403 --workers 3 --name my_cluster

--- a/cs_troubleshoot.md
+++ b/cs_troubleshoot.md
@@ -29,9 +29,6 @@ You can take some general steps to ensure that your clusters are up-to-date:
 - [Reboot your worker nodes](cs_cli_reference.html#cs_worker_reboot) regularly to ensure the installation of updates and security patches that IBM automatically deploys to the operating system
 - Update your cluster to [the latest default version of Kubernetes](cs_versions.html) for {{site.data.keyword.containershort_notm}}
 
-<br />
-
-
 ## Debugging clusters
 {: #debug_clusters}
 

--- a/cs_troubleshoot_clusters.md
+++ b/cs_troubleshoot_clusters.md
@@ -25,9 +25,6 @@ lastupdated: "2018-03-30"
 As you use {{site.data.keyword.containerlong}}, consider these techniques for troubleshooting your clusters and worker nodes. Before trying these techniques, you can take some general steps to [debug your cluster and check for common issues](cs_troubleshoot.html).
 {: shortdesc}
 
-<br />
-
-
 ## Unable to connect to your infrastructure account
 {: #cs_credentials}
 
@@ -221,10 +218,10 @@ If your app runs in the `default` namespace, uses the `default ServiceAccount`, 
 {: tsResolve}
 Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to your cluster.
 
-1.  **Temporary action**: As you update your app RBAC policies, you might want to revert temporarily to the previous `ClusterRoleBinding` for the `default ServiceAccount` in the `default` namespace. 
-    
+1.  **Temporary action**: As you update your app RBAC policies, you might want to revert temporarily to the previous `ClusterRoleBinding` for the `default ServiceAccount` in the `default` namespace.
+
     1.  Copy the following `.yaml` file.
-        
+
         ```yaml
         kind: ClusterRoleBinding
         apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -254,12 +251,12 @@ Before you begin, [target your CLI](cs_cli_install.html#cs_cli_configure) to you
         ```
 
     2.  Apply the `.yaml` files to your cluster.
-        
+
         ```
         kubectl apply -f FILENAME
         ```
         {: pre}
-        
+
 2.  [Create RBAC authorization resources![External link icon](../icons/launch-glyph.svg "External link icon")](https://kubernetes.io/docs/admin/authorization/rbac/#api-overview) to update the `ClusterRoleBinding` admin access.
 
 3.  If you created a temporary cluster role binding, remove it.

--- a/cs_troubleshoot_health.md
+++ b/cs_troubleshoot_health.md
@@ -25,9 +25,6 @@ lastupdated: "2018-03-30"
 As you use {{site.data.keyword.containerlong}}, consider these techniques for troubleshooting cluster logging and monitoring. Before trying these techniques, you can take some general steps to [debug your cluster and check for common issues](cs_troubleshoot.html).
 {: shortdesc}
 
-<br />
-
-
 ## Logs do not appear
 {: #cs_no_logs}
 

--- a/cs_troubleshoot_network.md
+++ b/cs_troubleshoot_network.md
@@ -25,7 +25,6 @@ lastupdated: "2018-03-30"
 As you use {{site.data.keyword.containerlong}}, consider these techniques for troubleshooting cluster networking. Before trying these techniques, you can take some general steps to [debug your cluster and check for common issues](cs_troubleshoot.html).
 {: shortdesc}
 
-<br />
 
 
 ## Cannot connect to an app via a load balancer service
@@ -55,31 +54,31 @@ To troubleshoot your load balancer service:
 
 2.  Check the accuracy of the configuration file for your load balancer service.
 
-  ```
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: myservice
-  spec:
-    type: LoadBalancer
-    selector:
-      <selectorkey>:<selectorvalue>
-    ports:
-     - protocol: TCP
-       port: 8080
-  ```
-  {: pre}
+    ```
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: myservice
+    spec:
+      type: LoadBalancer
+      selector:
+        <selectorkey>:<selectorvalue>
+      ports:
+       - protocol: TCP
+         port: 8080
+    ```
+    {: pre}
 
     1.  Check that you defined **LoadBalancer** as the type for your service.
-    2.  Make sure that you used the same **<selectorkey>** and **<selectorvalue>** that you used in the **label/metadata** section when you deployed your app.
+    2.  Make sure that the **<selectorkey>** and **<selectorvalue>** that you use in the `spec.selector` section of the LoadBalancer service is the same as the key/ value pair that you used in the `spec.template.metadata.labels` section of your deployment yaml. If labels do not match, the **Endpoints** section in your LoadBalancer service displays **<none>** and your app is not accessible from the internet. 
     3.  Check that you used the **port** that your app listens on.
 
 3.  Check your load balancer service and review the **Events** section to find potential errors.
 
-  ```
-  kubectl describe service <myservice>
-  ```
-  {: pre}
+    ```
+    kubectl describe service <myservice>
+    ```
+    {: pre}
 
     Look for the following error messages:
 
@@ -94,14 +93,16 @@ To troubleshoot your load balancer service:
 4.  If you are using a custom domain to connect to your load balancer service, make sure that your custom domain is mapped to the public IP address of your load balancer service.
     1.  Find the public IP address of your load balancer service.
 
-      ```
-      kubectl describe service <myservice> | grep "LoadBalancer Ingress"
-      ```
-      {: pre}
+        ```
+        kubectl describe service <myservice> | grep "LoadBalancer Ingress"
+        ```
+        {: pre}
 
     2.  Check that your custom domain is mapped to the portable public IP address of your load balancer service in the Pointer record (PTR).
 
 <br />
+
+
 
 
 ## Cannot connect to an app via Ingress
@@ -247,6 +248,7 @@ To troubleshoot your Ingress:
 
 
 
+
 ## Ingress application load balancer secret issues
 {: #cs_albsecret_fails}
 
@@ -287,6 +289,8 @@ Review the following reasons why the application load balancer secret might fail
  </tbody></table>
 
 <br />
+
+
 
 
 ## Cannot establish VPN connectivity with the strongSwan Helm chart
@@ -349,6 +353,8 @@ When you try to establish VPN connectivity with the strongSwan Helm chart, it is
         The tool outputs several pages of information as it runs various tests for common networking issues. Output lines that begin with `ERROR`, `WARNING`, `VERIFY`, or `CHECK` indicate possible errors with the VPN connectivity.
 
     <br />
+
+
 
 
 ## strongSwan VPN connectivity fails after worker node addition or deletion
@@ -427,7 +433,7 @@ Update the Helm chart values to reflect the worker node changes:
      <tbody>
      <tr>
      <td><code>localSubnetNAT</code></td>
-     <td>If you are using subnet NAT to remap specific private local IP addresses, remove any IP addresses from the old worker node. If you are using subnet NAT to remap entire subnets and you have no worker nodes remaining on a subnet, remove that subnet CIDR from this setting.</td>
+     <td>If you are using subnet NAT to remap specific private local IP addresses, remove any IP addresses from this setting that are from the old worker node. If you are using subnet NAT to remap entire subnets and you have no worker nodes remaining on a subnet, remove that subnet CIDR from this setting.</td>
      </tr>
      <tr>
      <td><code>nodeSelector</code></td>
@@ -435,7 +441,7 @@ Update the Helm chart values to reflect the worker node changes:
      </tr>
      <tr>
      <td><code>tolerations</code></td>
-     <td>If worker node you deleted was not tainted, but the only worker nodes that remain are tainted, change this setting to allow the VPN pod to run on all tainted worker nodes or worker nodes with specific taints.
+     <td>If the worker node that you deleted was not tainted, but the only worker nodes that remain are tainted, change this setting to allow the VPN pod to run on all tainted worker nodes or worker nodes with specific taints.
      </td>
      </tr>
      </tbody></table>
@@ -481,6 +487,8 @@ Update the Helm chart values to reflect the worker node changes:
 <br />
 
 
+
+
 ## Cannot retrieve the ETCD URL for Calico CLI configuration
 {: #cs_calico_fails}
 
@@ -512,6 +520,8 @@ To retrieve the `<ETCD_URL>`, run one of the following commands:
 When you retrieve the `<ETCD_URL>`, continue with the steps as listed in (Adding network policies)[cs_network_policy.html#adding_network_policies].
 
 <br />
+
+
 
 
 ## Getting help and support

--- a/cs_troubleshoot_storage.md
+++ b/cs_troubleshoot_storage.md
@@ -25,9 +25,6 @@ lastupdated: "2018-03-30"
 As you use {{site.data.keyword.containerlong}}, consider these techniques for troubleshooting cluster networking. Before trying these techniques, you can take some general steps to [debug your cluster and check for common issues](cs_troubleshoot.html).
 {: shortdesc}
 
-<br />
-
-
 ## File systems for worker nodes change to read-only
 {: #readonly_nodes}
 

--- a/cs_tutorials_cf.md
+++ b/cs_tutorials_cf.md
@@ -1,0 +1,300 @@
+<staging>
+---
+
+copyright:
+  years: 2014, 2018
+lastupdated: "2017-04-02"
+
+---
+
+{:new_window: target="_blank"}
+{:shortdesc: .shortdesc}
+{:screen: .screen}
+{:pre: .pre}
+{:table: .aria-labeledby="caption"}
+{:codeblock: .codeblock}
+{:tip: .tip}
+{:download: .download}
+
+
+# Tutorial: Deploying a Cloud Foundry Node.js app in a cluster
+{: #cf_tutorial}
+
+You can take an app that you deployed previously by using Cloud Foundry and deploy the same code in a container to a Kubernetes cluster in  {{site.data.keyword.containershort_notm}}.
+{: shortdesc}
+
+
+## Objectives
+
+- Learn the general process of deploying containers to a Kubernetes cluster
+- Learn what must be included in a Dockerfile to build a container image
+
+## Time required
+30 minutes
+
+## Audience
+Cloud Foundry app developers
+
+## Prerequisites
+
+- [Create a private image registry in IBM Cloud Container Registry](../services/Registry/index.html).
+- [Create a cluster](cs_clusters.html#clusters_ui).
+- [Target your CLI to the cluster](cs_cli_install.html#cs_cli_configure).
+
+
+<br />
+
+
+
+## Lesson 1: Download Cloud Foundry Node.js app code
+
+Get your Node.js code ready to go. Don't have any code yet? You can download starter code to use in this tutorial.
+{: shortdesc}
+
+To get and organize the app code:
+
+1. Create a directory that is named `cf-pi` and navigate into it. In this directory, you save all the files that are required to build the Docker image and to run your Node.js app. You can use any name for the directory. 
+
+  ```
+  mkdir cf-pi && cd cf-pi
+  ```
+  {: pre}
+
+2. Copy the Node.js app code and all related files into the directory. You can use your own Node.js app code or download the Personal Insights app from Cloud. To download the Personal Insights app code from Cloud, follow these steps.
+
+  a. In the catalog, in **Boilerplates**, click **Personality Insights Node.js Web Starter**. This boilerplate includes a Node.js app that uses the IBM Watson Personality Insights service to extract a spectrum of cognitive and social characteristics from a text that a person generates through blogs, tweets, or forum posts.
+  
+  b. Enter the app name `cf-pi-_myinitials_` and click **CREATE**. To access the app code for the boilerplate, you must deploy the CF app to the cloud first. You can use any name for the app. If you use the name from the example, replace `myinitials` with your initials, such as `cf-pi-ms`, to ensure that the name is unique.
+
+  This deployment creates an app that is named `cf-pi-myinitials` as well as an instance of the IBM Watson Personality Insights service that is named `cf-pi-myinitials-personality_insights`.
+
+  As the app is deployed, instructions for Deploying your app with the command line interface are displayed.
+  
+  c. From step 1, click **DOWNLOAD STARTER CODE**.
+  
+  d. Extract the .zip file and save the app files to your `cf-pi` directory.
+        
+Your Cloud Foundry app code is ready to be containerized!
+
+
+<br />
+
+
+## Lesson 2: Creating a Docker image with your CF app code
+
+Create a Dockerfile that includes your Node.js app code and the necessary configurations for your container. Then, build a Docker image from that Dockerfile and push it to your private Cloud registry.
+{: shortdesc}
+
+To create a Docker image with your app code, follow these steps.
+
+1. In the `cf-pi` directory that you created in the previous lesson, create a `Dockerfile`, which is the basis for creating a container. You can create the Dockerfile by using your preferred CLI editor or a text editor on your computer. The following example shows how to create a Dockerfile file with the nano editor.
+
+  ```
+  nano Dockerfile
+  ```
+  {: pre}
+
+2. Copy the following script into the Dockerfile.
+
+  ```
+  #Use the Node image from DockerHub as a base image
+  FROM node:latest
+
+  #Expose the port for your Personal Insights app, and set
+  #it as an environment variable as expected by cf apps
+  ENV PORT=3000
+  EXPOSE 3000
+  ENV NODE_ENV production
+
+  #Copy all app files from the current directory into the app
+  #directory in your container. Set the app directory
+  #as the working directory
+  ADD . /personality-insights-nodejs-master/
+  WORKDIR /personality-insights-nodejs-master/
+
+  #Install any necessary requirements from package.json
+  RUN npm install
+  
+  #Update the curl and openssl packages
+  RUN apt-get update && apt-get install -y \
+    curl \
+    openssl
+
+  #Start the Personal Insight app.
+  CMD ["node", "/personality-insights-nodejs-master/app.js"]
+  ```
+  {: codeblock}
+
+3. Save your changes by pressing `ctrl + o`. Confirm your changes by pressing `ENTER`. Exit the nano editor by pressing `ctrl + x`.
+
+4. Build the Docker image with your app code and push it to your private registry.
+
+  ```
+  bx cr build -t registry.<region>.bluemix.net/namespace/cf-pi .
+  ```
+  {: pre}
+  
+  <table>
+  <thead>
+  <th colspan=2><img src="images/idea.png" alt="This icon indicates there is more information to learn about this step of the task."/> Understanding this command's components</th>
+  </thead>
+  <tbody>
+  <tr>
+  <td>Parameter</td>
+  <td>Description</td>
+  </tr>
+  <tr>
+  <td><code>build</code></td>
+  <td>The build command.</td>
+  </tr>
+  <tr>
+  <td><code>-t registry.<region>.bluemix.net/namespace/cf-pi</code></td>
+  <td>Your private registry path, which includes your unique namespace and the name of the image. For this example, the same name is used for the image as the CF node app cf-pi, but you can choose any name for the image in your private registry. If you are unsure what your namespace is, run the `bx cr namespaces` command to find it.</td>
+  </tr>
+  <tr>
+  <td><code>.</code></td>
+  <td>The location of the Dockerfile. If you are running the build command from the directory that includes the Dockerfile, enter a period (.). Otherwise, use a relative path to the Dockerfile.</td>
+  </tr>
+  </table>
+
+  The image is created in your registry. You can run the `bx cr images` command to verify that the image was created.
+
+  ```
+  REPOSITORY                                     NAMESPACE   TAG      DIGEST         CREATED         SIZE     VULNERABILITY STATUS   
+  registry.ng.bluemix.net/namespace/cf-pi        namespace   latest   cb03170b2cb2   3 minutes ago   271 MB   Vulnerable 
+  ```
+  {: pre}
+
+
+<br />
+
+
+
+## Lesson 3: Deploying a container from your image
+
+Deploy your app as a container in the cloud.
+{: shortdesc}
+
+1. Create a deployment from the image that you created in the previous lesson.
+
+  ```
+  kubectl run cf-pi-deployment --image=registry.<region>.bluemix.net/<namespace>/cf-pi:latest
+  ```
+  {: pre}
+
+  <table>
+  <thead>
+  <th colspan=2><img src="images/idea.png" alt="This icon indicates there is more information to learn about this step of the task."/> Understanding this command's components</th>
+  </thead>
+  <tbody>
+  <tr>
+  <td>Parameter</td>
+  <td>Description</td>
+  </tr>
+  <tr>
+  <td><code>run</code></td>
+  <td>The command to create a Kubernetes deployment that includes a container</td>
+  </tr>
+  <tr>
+  <td><code>cf-pi-deployment</code></td>
+  <td>The name of the Kubernetes deployment resource</td>
+  </tr>
+  <tr>
+  <td><code>--image=registry.<region>.bluemix.net/<namespace>/cf-pi:latest</code></td>
+  <td>The image to deploy the container from</td>
+  </tr>
+  </table>
+
+2. Make the app accessible to the world by exposing the deployment as a NodePort service. Just as you might expose a port for a Cloud Foundry app, the NodePort you expose is the port on which the worker node listens for traffic.
+
+    ```
+    kubectl expose deployment/cf-pi-deployment --type=NodePort --port=8080 --name=cf-pi-service --target-port=8080
+    ```
+    {: pre}
+
+    <table>
+    <thead>
+    <th colspan=2><img src="images/idea.png" alt="This icon indicates there is more information to learn about this step of the task."/> Understanding this command's components</th>
+    </thead>
+    <tbody>
+    <tr>
+    <td>Parameter</td>
+    <td>Description</td>
+    </tr>
+    <tr>
+    <td><code>expose</code></td>
+    <td>The command to create a Kubernetes service resource</td>
+    </tr>
+    <tr>
+    <td><code>deployment/cf-pi-deployment</code></td>
+    <td>The name of the deployment to expose from the service</td>
+    </tr>
+    <tr>
+    <td><code>--type=NodePort</code></td>
+    <td>The type of networking to use</td>
+    </tr>
+    <tr>
+    <td><code>--port=8080</code></td>
+    <td>The port on which the service should serve</td>
+    </tr>
+    <tr>
+    <td><code>--name=cf-pi-service</code></td>
+    <td>The name of the service</td>
+    </tr>
+    <tr>
+    <td><code>--target-port=8080</code></td>
+    <td>The port to which the service directs traffic. In this instance, the target-port is the same as the port, but other apps you create might differ.</td>
+    </tr>
+    </table>
+    
+3. Now that all the deployment work is done, you can test your app in a browser. Get the details to form the URL.
+    
+    a.  Get information about the service to see which NodePort was assigned.
+
+    ```
+    kubectl describe service cf-pi-service
+    ```
+    {: pre}
+
+    Output:
+
+    ```
+    Name:                   cf-pi-service
+    Namespace:              default
+    Labels:                 run=cf-pi-deployment
+    Selector:               run=cf-pi-deployment
+    Type:                   NodePort
+    IP:                     10.10.10.8
+    Port:                   <unset> 8080/TCP
+    NodePort:               <unset> 30872/TCP
+    Endpoints:              172.30.171.87:8080
+    Session Affinity:       None
+    No events.
+    ```
+    {: screen}
+
+      The NodePorts are randomly assigned when they are generated with the `expose` command, but within 30000-32767. In this example, the NodePort is 30872.
+
+    b.  Get the public IP address for the worker node in the cluster.
+
+    ```
+    bx cs workers <cluster_name>
+    ```
+    {: pre}
+
+    Output:
+
+    ```
+    ID                                                 Public IP        Private IP     Machine Type        State    Status   Zone    Version   
+    kube-dal10-cr18e61e63c6e94b658596ca93d087eed9-w1   169.47.227.138   10.176.48.67   u2c.2x4.encrypted   normal   Ready    dal10   1.8.8
+    ```
+    {: screen}
+
+4. Open a browser and check out the app with the following URL: `http://<IP_address>:<NodePort>`. With the example values, the URL is `http://169.47.227.138:30872`. You can give this URL to a co-worker to try or enter it in your cell phone's browser, so that you can see that the app really is publicly available.
+
+5. [Launch the Kubernetes dashboard](cs_app.html#cli_dashboard). Note that the steps differ depending on your version of Kubernetes.
+
+6. In the **Workloads** tab, you can see the resources that you created. When you are done exploring the Kubernetes dashboard, use CTRL+C to exit the `proxy` command.
+
+Congratulations! Your app is deployed in a container!
+<staging>


### PR DESCRIPTION
This PR includes the following changes:
typos
Merge pull request #1488 from alchemy-containers/cf-tutorial
Merge pull request #1484 from alchemy-containers/subnet-reuse
Merge branch 'master' of https://github.ibm.com/alchemy-containers/documentation
Updated formatting
Updated formatting
Updated date
Updated download steps
Update cs_troubleshoot_network.md
Update cs_troubleshoot_network.md
typo
Added line breaks
Delete cs_apps.md
Merge pull request #1482 from alchemy-containers/name-reuse