### PR TITLE
Replace bash by sh with the command kubectl exec

### DIFF
--- a/cs_integrations.md
+++ b/cs_integrations.md
@@ -473,7 +473,7 @@ When you mount the secret as a volume to your pod, a file that is named `binding
 5.  Access the service credentials. 
     1. Log in to your pod. 
        ```
-       kubectl exec <pod_name> -it bash
+       kubectl exec <pod_name> -it -- /bin/sh
        ```
        {: pre}
        


### PR DESCRIPTION
Using bash does not work as it returns the following error: OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"bash\": executable file not found in $PATH": unknown