### PR TITLE
Fix typos in YAML example for PV

### DIFF
--- a/cs_storage_block.md
+++ b/cs_storage_block.md
@@ -674,8 +674,8 @@ Before you can start to mount your existing storage to an app, you must retrieve
     metadata:
       name: mypv
       labels:
-         failure-domain.beta.kubernetes.io/region=<region>
-         failure-domain.beta.kubernetes.io/zone=<zone>
+         failure-domain.beta.kubernetes.io/region: <region>
+         failure-domain.beta.kubernetes.io/zone: <zone>
     spec:
       capacity:
         storage: "<storage_size>"


### PR DESCRIPTION
The YAML for a PV contains a typo (x2).