### PR TITLE
Update file with export option for IKS config file

### DIFF
--- a/cs_cli_install.md
+++ b/cs_cli_install.md
@@ -240,6 +240,7 @@ To use `kubectl` commands:
     2.  Copy and paste the command that is displayed in your terminal to set the `KUBECONFIG` environment variable.
 
         **Mac or Linux user**: Instead of running the `ibmcloud ks cluster-config` command and copying the `KUBECONFIG` environment variable, you can run `ibmcloud ks cluster-config --export <cluster-name>`.
+        Depending on your shell, you could execute `eval $(ibmcloud ks cluster-config --export <cluster-name>)` to setup your current shell.
         {:tip}
 
     3.  Verify that the `KUBECONFIG` environment variable is set properly.

--- a/cs_cli_install.md
+++ b/cs_cli_install.md
@@ -239,7 +239,7 @@ To use `kubectl` commands:
 
     2.  Copy and paste the command that is displayed in your terminal to set the `KUBECONFIG` environment variable.
 
-        **Mac or Linux user**: Instead of running the `ibmcloud ks cluster-config` command and copying the `KUBECONFIG` environment variable, you can run `(ibmcloud ks cluster-config "<cluster-name>" | grep export)`.
+        **Mac or Linux user**: Instead of running the `ibmcloud ks cluster-config` command and copying the `KUBECONFIG` environment variable, you can run `ibmcloud ks cluster-config --export <cluster-name>`.
         {:tip}
 
     3.  Verify that the `KUBECONFIG` environment variable is set properly.


### PR DESCRIPTION
Add mention of the `--export` option and add a suggestion on how to setup the environment using `eval` and the `ibmcloud ks cluster-config --export` command.