### PR TITLE
Change container name  - DNS-1123 compliant label

### DIFF
--- a/cs_troubleshoot_storage.md
+++ b/cs_troubleshoot_storage.md
@@ -147,7 +147,7 @@ Before you begin: [Log in to your account. Target the appropriate region and, if
 
     ```
     initContainers:
-    - name: initContainer # Or you can replace with any name
+    - name: initcontainer # Or you can replace with any name
       image: alpine:latest
       command: ["/bin/sh", "-c"]
       args:


### PR DESCRIPTION
`initContainer ` is an Invalid value and throws this error on K8S version 1.12.x 
"initContainer": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name', or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')