### PR TITLE
Fixed link to helm chart

### DIFF
--- a/cs_troubleshoot_debug_ingress.md
+++ b/cs_troubleshoot_debug_ingress.md
@@ -43,7 +43,7 @@ Before you begin, ensure you have the following [{{site.data.keyword.Bluemix_not
 
 ## Step 1: Run Ingress tests in the {{site.data.keyword.containerlong_notm}} Diagnostics and Debug Tool
 
-While you troubleshoot, you can use the {{site.data.keyword.containerlong_notm}} Diagnostics and Debug Tool to run Ingress tests and gather pertinent Ingress information from your cluster. To use the debug tool, install the [`ibmcloud-iks-debug` Helm chart ![External link icon](../icons/launch-glyph.svg "External link icon")](https://cloud.ibm.com/kubernetes/solutions/helm-charts/iks-charts/ibmcloud-iks-debug):
+While you troubleshoot, you can use the {{site.data.keyword.containerlong_notm}} Diagnostics and Debug Tool to run Ingress tests and gather pertinent Ingress information from your cluster. To use the debug tool, install the [`ibmcloud-iks-debug` Helm chart ![External link icon](../icons/launch-glyph.svg "External link icon")](https://cloud.ibm.com/kubernetes/helm/iks-charts/ibmcloud-iks-debug):
 {: shortdesc}
 
 


### PR DESCRIPTION
Link to iks-debug helm chart is broken. I put the new link
https://cloud.ibm.com/kubernetes/helm/iks-charts/ibmcloud-iks-debug