### PR TITLE
Helm command to fetch chart needs to be corrected

### DIFF
--- a/cs_storage_block.md
+++ b/cs_storage_block.md
@@ -197,7 +197,7 @@ Before you begin: [Log in to your account. If applicable, target the appropriate
 
 2. Optional: Download the latest Helm chart to your local machine. Then, extract the package and review the `release.md` file to find the latest release information.
    ```
-   helm fetch iks-charts/ibmcloud-block-storage-plugin
+   helm fetch ibm/ibmcloud-block-storage-plugin
    ```
    {: pre}
 


### PR DESCRIPTION
The `helm fetch` example doesn't work:

```
 helm repo update
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "ibmcase" chart repository
...Successfully got an update from the "ibm" chart repository
...Successfully got an update from the "ibm-charts" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈
```

```
helm fetch ibm-charts/ibmcloud-block-storage-plugin
Error: chart "ibmcloud-block-storage-plugin" matching  not found in ibm-charts index. (try 'helm repo update'). no chart name found
```

```
helm version
Client: &version.Version{SemVer:"v2.9.1", GitCommit:"20adb27c7c5868466912eebdf6664e7390ebe710", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.9.1", GitCommit:"20adb27c7c5868466912eebdf6664e7390ebe710", GitTreeState:"clean"}
```

Corrected with what seems the right command