### PR TITLE
Updated endpoint resource example

### DIFF
--- a/cs_ingress.md
+++ b/cs_ingress.md
@@ -576,7 +576,7 @@ To expose apps that are outside your cluster to the public:
         kind: Endpoints
         apiVersion: v1
         metadata:
-          name: myexternalendpoint
+          name: myexternalservice
         subsets:
           - addresses:
               - ip: <external_IP1>


### PR DESCRIPTION
Per https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors the service and endpoint names have to be the same.